### PR TITLE
Add support for generic adaptor

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,7 @@ module.exports = function (grunt) {
       dist: {
         src: [
           'WebCola/compiledtypescript.js',
-          'WebCola/src/d3adaptor.js',
+          'WebCola/src/adaptor.js',
           'WebCola/src/rbtree.js',
           'WebCola/src/scc.js',
           'WebCola/src/handle_disconnected.js'

--- a/WebCola/WebCola.csproj
+++ b/WebCola/WebCola.csproj
@@ -39,7 +39,7 @@
     <Content Include="examples\ariel.html" />
     <Content Include="examples\unix.html" />
     <Content Include="examples\unix.png" />
-    <Content Include="src\d3adaptor.js" />
+    <Content Include="src\adaptor.js" />
     <Content Include="examples\smallgroups.html" />
     <Content Include="examples\graphdata\biological_images\C00002.gif">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/WebCola/brain-app/brainapp.html
+++ b/WebCola/brain-app/brainapp.html
@@ -527,7 +527,7 @@
 
     <script src="../cola.v3.min.js"></script>
     <script src="../src/descent.js"></script>
-    <script src="../src/d3adaptor.js"></script>
+    <script src="../src/adaptor.js"></script>
 
     <!-- The main application script -->
     <script src="brainapp.js"></script>

--- a/WebCola/cola.v3.min.js
+++ b/WebCola/cola.v3.min.js
@@ -1,2 +1,4107 @@
-var cola;!function(a){var b=function(){function a(){this.locks={}}return a.prototype.add=function(a,b){isNaN(b[0])||isNaN(b[1]),this.locks[a]=b},a.prototype.clear=function(){this.locks={}},a.prototype.isEmpty=function(){for(var a in this.locks)return!1;return!0},a.prototype.apply=function(a){for(var b in this.locks)a(b,this.locks[b])},a}();a.Locks=b;var c=function(){function a(a,c,e){"undefined"==typeof e&&(e=null),this.D=c,this.G=e,this.threshold=1e-4,this.random=new d,this.project=null,this.x=a,this.k=a.length;var f=this.n=a[0].length;this.H=new Array(this.k),this.g=new Array(this.k),this.Hd=new Array(this.k),this.a=new Array(this.k),this.b=new Array(this.k),this.c=new Array(this.k),this.d=new Array(this.k),this.e=new Array(this.k),this.ia=new Array(this.k),this.ib=new Array(this.k),this.xtmp=new Array(this.k),this.locks=new b,this.minD=Number.MAX_VALUE;for(var g,h=f;h--;)for(g=f;--g>h;){var i=c[h][g];i>0&&i<this.minD&&(this.minD=i)}for(this.minD===Number.MAX_VALUE&&(this.minD=1),h=this.k;h--;){for(this.g[h]=new Array(f),this.H[h]=new Array(f),g=f;g--;)this.H[h][g]=new Array(f);this.Hd[h]=new Array(f),this.a[h]=new Array(f),this.b[h]=new Array(f),this.c[h]=new Array(f),this.d[h]=new Array(f),this.e[h]=new Array(f),this.ia[h]=new Array(f),this.ib[h]=new Array(f),this.xtmp[h]=new Array(f)}}return a.createSquareMatrix=function(a,b){for(var c=new Array(a),d=0;a>d;++d){c[d]=new Array(a);for(var e=0;a>e;++e)c[d][e]=b(d,e)}return c},a.prototype.offsetDir=function(){for(var a=this,b=new Array(this.k),c=0,d=0;d<this.k;++d){var e=b[d]=this.random.getNextBetween(.01,1)-.5;c+=e*e}return c=Math.sqrt(c),b.map(function(b){return b*=a.minD/c})},a.prototype.computeDerivatives=function(a){var b=this,c=this.n;if(!(1>c)){for(var d,e=new Array(this.k),f=new Array(this.k),g=new Array(this.k),h=0,i=0;c>i;++i){for(d=0;d<this.k;++d)g[d]=this.g[d][i]=0;for(var j=0;c>j;++j)if(i!==j){for(;;){var k=0;for(d=0;d<this.k;++d){var l=e[d]=a[d][i]-a[d][j];k+=f[d]=l*l}if(k>1e-9)break;var m=this.offsetDir();for(d=0;d<this.k;++d)a[d][j]+=m[d]}var n=Math.sqrt(k),o=this.D[i][j],p=null!=this.G?this.G[i][j]:1;if(p>1&&n>o||!isFinite(o))for(d=0;d<this.k;++d)this.H[d][i][j]=0;else{p>1&&(p=1);var q=o*o,r=p*(n-o)/(q*n),s=-p/(q*n*n*n);for(isFinite(r)||console.log(r),d=0;d<this.k;++d)this.g[d][i]+=e[d]*r,g[d]-=this.H[d][i][j]=s*(o*(f[d]-k)+n*k)}}for(d=0;d<this.k;++d)h=Math.max(h,this.H[d][i][i]=g[d])}this.locks.isEmpty()||this.locks.apply(function(c,e){for(d=0;d<b.k;++d)b.H[d][c][c]+=h,b.g[d][c]-=h*(e[d]-a[d][c])})}},a.dotProd=function(a,b){for(var c=0,d=a.length;d--;)c+=a[d]*b[d];return c},a.rightMultiply=function(b,c,d){for(var e=b.length;e--;)d[e]=a.dotProd(b[e],c)},a.prototype.computeStepSize=function(b){for(var c=0,d=0,e=0;2>e;++e)c+=a.dotProd(this.g[e],b[e]),a.rightMultiply(this.H[e],b[e],this.Hd[e]),d+=a.dotProd(b[e],this.Hd[e]);return 0!==d&&isFinite(d)?c/d:0},a.prototype.reduceStress=function(){this.computeDerivatives(this.x);for(var a=this.computeStepSize(this.g),b=0;b<this.k;++b)this.takeDescentStep(this.x[b],this.g[b],a);return this.computeStress()},a.copy=function(a,b){for(var c=a.length,d=b[0].length,e=0;c>e;++e)for(var f=0;d>f;++f)b[e][f]=a[e][f]},a.prototype.stepAndProject=function(b,c,d,e){a.copy(b,c),this.takeDescentStep(c[0],d[0],e),this.project&&this.project[0](b[0],b[1],c[0]),this.takeDescentStep(c[1],d[1],e),this.project&&this.project[1](c[0],b[1],c[1])},a.mApply=function(a,b,c){for(var d=a;d-->0;)for(var e=b;e-->0;)c(d,e)},a.prototype.matrixApply=function(b){a.mApply(this.k,this.n,b)},a.prototype.computeNextPosition=function(a,b){var c=this;this.computeDerivatives(a);var d=this.computeStepSize(this.g);this.stepAndProject(a,b,this.g,d);for(var e=0;e<this.n;++e)for(var f=0;f<this.k;++f)isNaN(b[f][e]);if(this.project){this.matrixApply(function(d,e){return c.e[d][e]=a[d][e]-b[d][e]});var g=this.computeStepSize(this.e);g=Math.max(.2,Math.min(g,1)),this.stepAndProject(a,b,this.e,g)}},a.prototype.run=function(a){for(var b=Number.MAX_VALUE,c=!1;!c&&a-->0;){var d=this.rungeKutta();c=Math.abs(b/d-1)<this.threshold,b=d}return b},a.prototype.rungeKutta=function(){var b=this;this.computeNextPosition(this.x,this.a),a.mid(this.x,this.a,this.ia),this.computeNextPosition(this.ia,this.b),a.mid(this.x,this.b,this.ib),this.computeNextPosition(this.ib,this.c),this.computeNextPosition(this.c,this.d);var c=0;return this.matrixApply(function(a,d){var e=(b.a[a][d]+2*b.b[a][d]+2*b.c[a][d]+b.d[a][d])/6,f=b.x[a][d]-e;c+=f*f,b.x[a][d]=e}),c},a.mid=function(b,c,d){a.mApply(b.length,b[0].length,function(a,e){return d[a][e]=b[a][e]+(c[a][e]-b[a][e])/2})},a.prototype.takeDescentStep=function(a,b,c){for(var d=0;d<this.n;++d)a[d]=a[d]-c*b[d]},a.prototype.computeStress=function(){for(var a=0,b=0,c=this.n-1;c>b;++b)for(var d=b+1,e=this.n;e>d;++d){for(var f=0,g=0;g<this.k;++g){var h=this.x[g][b]-this.x[g][d];f+=h*h}f=Math.sqrt(f);var i=this.D[b][d];if(isFinite(i)){var j=i-f,k=i*i;a+=j*j/k}}return a},a.zeroDistance=1e-10,a}();a.Descent=c;var d=function(){function a(a){"undefined"==typeof a&&(a=1),this.seed=a,this.a=214013,this.c=2531011,this.m=2147483648,this.range=32767}return a.prototype.getNext=function(){return this.seed=(this.seed*this.a+this.c)%this.m,(this.seed>>16)/this.range},a.prototype.getNextBetween=function(a,b){return a+this.getNext()*(b-a)},a}();a.PseudoRandom=d}(cola||(cola={}));var __extends=this.__extends||function(a,b){function c(){this.constructor=a}for(var d in b)b.hasOwnProperty(d)&&(a[d]=b[d]);c.prototype=b.prototype,a.prototype=new c},cola;!function(a){!function(b){function c(a,b,c){return(b.x-a.x)*(c.y-a.y)-(c.x-a.x)*(b.y-a.y)}function d(a,b,d){return c(a,b,d)>0}function e(a,b,d){return c(a,b,d)<0}function f(a){var b,d=a.slice(0).sort(function(a,b){return a.x!==b.x?b.x-a.x:b.y-a.y}),e=a.length,f=0,g=d[0].x;for(b=1;e>b&&d[b].x===g;++b);var h=b-1,i=[];if(i.push(d[f]),h===e-1)d[h].y!==d[f].y&&i.push(d[h]);else{var j,k=e-1,l=d[e-1].x;for(b=e-2;b>=0&&d[b].x===l;b--);for(j=b+1,b=h;++b<=j;)if(!(c(d[f],d[j],d[b])>=0&&j>b)){for(;i.length>1&&!(c(i[i.length-2],i[i.length-1],d[b])>0);)i.length-=1;b!=f&&i.push(d[b])}k!=j&&i.push(d[k]);var m=i.length;for(b=j;--b>=h;)if(!(c(d[k],d[h],d[b])>=0&&b>h)){for(;i.length>m&&!(c(i[i.length-2],i[i.length-1],d[b])>0);)i.length-=1;b!=f&&i.push(d[b])}}return i}function g(a,b,c){b.slice(0).sort(function(b,c){return Math.atan2(b.y-a.y,b.x-a.x)-Math.atan2(c.y-a.y,c.x-a.x)}).forEach(c)}function h(a,b){return{rtan:i(a,b),ltan:j(a,b)}}function i(a,b){var c,f,g,h,i,j=b.length-1;if(e(a,b[1],b[0])&&!d(a,b[j-1],b[0]))return 0;for(c=0,f=j;;){if(f-c===1)return d(a,b[c],b[f])?c:f;if(g=Math.floor((c+f)/2),i=e(a,b[g+1],b[g]),i&&!d(a,b[g-1],b[g]))return g;h=d(a,b[c+1],b[c]),h?i?f=g:d(a,b[c],b[g])?f=g:c=g:i&&e(a,b[c],b[g])?f=g:c=g}}function j(a,b){var c,f,g,h,i,j=b.length-1;if(d(a,b[j-1],b[0])&&!e(a,b[1],b[0]))return 0;for(c=0,f=j;;){if(f-c===1)return e(a,b[c],b[f])?c:f;if(g=Math.floor((c+f)/2),i=e(a,b[g+1],b[g]),d(a,b[g-1],b[g])&&!i)return g;h=e(a,b[c+1],b[c]),h?i?e(a,b[c],b[g])?f=g:c=g:f=g:i?c=g:d(a,b[c],b[g])?f=g:c=g}}function k(a,b,c,d,e,f){var g,h;g=c(b[0],a),h=d(a[g],b);for(var i=!1;!i;){for(i=!0;;){if(g===a.length-1&&(g=0),e(b[h],a[g],a[g+1]))break;++g}for(;;){if(0===h&&(h=b.length-1),f(a[g],b[h],b[h-1]))break;--h,i=!1}}return{t1:g,t2:h}}function l(a,b){var c=m(b,a);return{t1:c.t2,t2:c.t1}}function m(a,b){return k(a,b,i,j,d,e)}function n(a,b){return k(a,b,j,j,e,e)}function o(a,b){return k(a,b,i,i,d,d)}function p(b,c){for(var d=[],e=1,f=c.length;f>e;++e){var g=a.vpsc.Rectangle.lineIntersection(b.x1,b.y1,b.x2,b.y2,c[e-1].x,c[e-1].y,c[e].x,c[e].y);g&&d.push(g)}return d}function q(a,b){for(var d=a.length-1,e=b.length-1,f=new y,g=0;d>g;++g)for(var h=0;e>h;++h){var i=a[0==g?d-1:g-1],j=a[g],k=a[g+1],l=b[0==h?e-1:h-1],m=b[h],n=b[h+1],o=c(i,j,m),p=c(j,l,m),q=c(j,m,n),r=c(l,m,j),s=c(m,i,j),t=c(m,j,k);o>=0&&p>=0&&0>q&&r>=0&&s>=0&&0>t?f.ll=new x(g,h):0>=o&&0>=p&&q>0&&0>=r&&0>=s&&t>0?f.rr=new x(g,h):0>=o&&p>0&&0>=q&&r>=0&&0>s&&t>=0?f.rl=new x(g,h):o>=0&&0>p&&q>=0&&0>=r&&s>0&&0>=t&&(f.lr=new x(g,h))}return f}function r(a,b){for(var c=1,d=b.length;d>c;++c)if(e(b[c-1],b[c],a))return!1;return!0}function s(a,b){return!a.every(function(a){return!r(a,b)})}function t(a,b){if(s(a,b))return!0;if(s(b,a))return!0;for(var c=1,d=a.length;d>c;++c){var e=a[c],f=a[c-1];if(p(new v(f.x,f.y,e.x,e.y),b).length>0)return!0}return!1}var u=function(){function a(){}return a}();b.Point=u;var v=function(){function a(a,b,c,d){this.x1=a,this.y1=b,this.x2=c,this.y2=d}return a}();b.LineSegment=v;var w=function(a){function b(){a.apply(this,arguments)}return __extends(b,a),b}(u);b.PolyPoint=w,b.isLeft=c,b.ConvexHull=f,b.clockwiseRadialSweep=g,b.tangent_PolyPolyC=k,b.LRtangent_PolyPolyC=l,b.RLtangent_PolyPolyC=m,b.LLtangent_PolyPolyC=n,b.RRtangent_PolyPolyC=o;var x=function(){function a(a,b){this.t1=a,this.t2=b}return a}();b.BiTangent=x;var y=function(){function a(){}return a}();b.BiTangents=y;var z=function(a){function b(){a.apply(this,arguments)}return __extends(b,a),b}(u);b.TVGPoint=z;var A=function(){function a(a,b,c,d){this.id=a,this.polyid=b,this.polyvertid=c,this.p=d,d.vv=this}return a}();b.VisibilityVertex=A;var B=function(){function a(a,b){this.source=a,this.target=b}return a.prototype.length=function(){var a=this.source.p.x-this.target.p.x,b=this.source.p.y-this.target.p.y;return Math.sqrt(a*a+b*b)},a}();b.VisibilityEdge=B;var C=function(){function a(a,c){if(this.P=a,this.V=[],this.E=[],c)this.V=c.V.slice(0),this.E=c.E.slice(0);else{for(var d=a.length,e=0;d>e;e++)for(var f=a[e],g=0;g<f.length;++g){var h=f[g],i=new A(this.V.length,e,g,h);this.V.push(i),g>0&&this.E.push(new B(f[g-1].vv,i))}for(var e=0;d-1>e;e++)for(var j=a[e],g=e+1;d>g;g++){var k=a[g],l=b.tangents(j,k);for(var m in l){var n=l[m],o=j[n.t1],p=k[n.t2];this.addEdgeIfVisible(o,p,e,g)}}}}return a.prototype.addEdgeIfVisible=function(a,b,c,d){this.intersectsPolys(new v(a.x,a.y,b.x,b.y),c,d)||this.E.push(new B(a.vv,b.vv))},a.prototype.addPoint=function(a,b){var c=this.P.length;this.V.push(new A(this.V.length,c,0,a));for(var d=0;c>d;++d)if(d!==b){var e=this.P[d],f=h(a,e);this.addEdgeIfVisible(a,e[f.ltan],b,d),this.addEdgeIfVisible(a,e[f.rtan],b,d)}return a.vv},a.prototype.intersectsPolys=function(a,b,c){for(var d=0,e=this.P.length;e>d;++d)if(d!=b&&d!=c&&p(a,this.P[d]).length>0)return!0;return!1},a}();b.TangentVisibilityGraph=C,b.tangents=q,b.polysOverlap=t}(a.geom||(a.geom={}));a.geom}(cola||(cola={}));var cola;!function(a){function b(a,b){var c={};for(var d in a)c[d]={};for(var d in b)c[d]={};return Object.keys(c).length}function c(a,b){var c=0;for(var d in a)"undefined"!=typeof b[d]&&++c;return c}function d(a,b){var c={},d=function(a,b){"undefined"==typeof c[a]&&(c[a]={}),c[a][b]={}};return a.forEach(function(a){var c=b.getSourceIndex(a),e=b.getTargetIndex(a);d(c,e),d(e,c)}),c}function e(a,b,c,e){var f=d(a,e);a.forEach(function(a){var d=f[e.getSourceIndex(a)],g=f[e.getTargetIndex(a)];e.setLength(a,1+b*c(d,g))})}function f(a,d,f){"undefined"==typeof f&&(f=1),e(a,f,function(a,d){return Math.sqrt(b(a,d)-c(a,d))},d)}function g(a,d,f){"undefined"==typeof f&&(f=1),e(a,f,function(a,d){return Math.min(Object.keys(a).length,Object.keys(d).length)<1.1?0:c(a,d)/b(a,d)},d)}function h(a,b,c,d){var e=i(a,b,d),f={};e.filter(function(a){return a.length>1}).forEach(function(a){return a.forEach(function(b){return f[b]=a})});var g=[];return b.forEach(function(a){var b=d.getSourceIndex(a),e=d.getTargetIndex(a),h=f[b],i=f[e];h&&i&&h.component===i.component||g.push({axis:c,left:b,right:e,gap:d.getMinSeparation(a)})}),g}function i(a,b,c){function d(a){f[a]=j,g[a]=j,h[a]=!0,j+=1,k.push(a);for(var b=e[a],c=0;c<b.length;++c){var i=b[c];f[i]<0?(d(i),g[a]=0|Math.min(g[a],g[i])):h[i]&&(g[a]=Math.min(g[a],g[i]))}if(g[a]===f[a]){for(var m=[],c=k.length-1;c>=0;--c){var n=k[c];if(h[n]=!1,m.push(n),n===a){k.length=c;break}}l.push(m)}}for(var e=new Array(a),f=new Array(a),g=new Array(a),h=new Array(a),i=0;a>i;++i)e[i]=[],f[i]=-1,g[i]=0,h[i]=!1;for(var i=0;i<b.length;++i)e[c.getSourceIndex(b[i])].push(c.getTargetIndex(b[i]));for(var j=0,k=[],l=[],i=0;a>i;++i)f[i]<0&&d(i);return l}a.symmetricDiffLinkLengths=f,a.jaccardLinkLengths=g,a.generateDirectedEdgeConstraints=h}(cola||(cola={}));var cola;!function(a){!function(a){function b(a,c,d){a.forAll(function(a){if(a.isLeaf())c.leaves||(c.leaves=[]),c.leaves.push(a.id);else{var e=c;a.gid=d.length,a.isIsland()||(e={id:a.gid},c.groups||(c.groups=[]),c.groups.push(a.gid),d.push(e)),b(a.children,e,d)}})}function c(a,b){var c={};for(var d in a)d in b&&(c[d]=a[d]);return c}function d(b,c,d){for(var e=b.length,f=new a.Configuration(e,c,d);f.greedyMerge(););var g=[],h=f.getGroupHierarchy(g);return g.forEach(function(a){var c=function(c){var d=a[c];"number"==typeof d&&(a[c]=b[d])};c("source"),c("target")}),{groups:h,powerEdges:g}}var e=function(){function a(a,b,c){this.source=a,this.target=b,this.type=c}return a}();a.PowerEdge=e;var f=function(){function a(a,b,c){var d=this;this.linkAccessor=c,this.modules=new Array(a),this.roots=new h;for(var e=0;a>e;++e)this.roots.add(this.modules[e]=new g(e));this.R=b.length,b.forEach(function(a){var b=d.modules[c.getSourceIndex(a)],e=d.modules[c.getTargetIndex(a)],f=c.getType(a);b.outgoing.add(f,e),e.incoming.add(f,b)})}return a.prototype.merge=function(a,b){var c=a.incoming.intersection(b.incoming),d=a.outgoing.intersection(b.outgoing),e=new h;e.add(a),e.add(b);var f=new g(this.modules.length,d,c,e);this.modules.push(f);var i=function(c,d,e){c.forAll(function(c,g){c.forAll(function(c){var h=c[d];h.add(g,f),h.remove(g,a),h.remove(g,b),a[e].remove(g,c),b[e].remove(g,c)})})};return i(d,"incoming","outgoing"),i(c,"outgoing","incoming"),this.R-=c.count()+d.count(),this.roots.remove(a),this.roots.remove(b),this.roots.add(f),f},a.prototype.rootMerges=function(){for(var a=this.roots.modules(),b=a.length,c=new Array(b*(b-1)),d=0,e=0,f=b-1;f>e;++e)for(var g=e+1;b>g;++g){var h=a[e],i=a[g];c[d++]={nEdges:this.nEdges(h,i),a:h,b:i}}return c},a.prototype.greedyMerge=function(){var a=this.rootMerges().sort(function(a,b){return a.nEdges-b.nEdges}),b=a[0];return b.nEdges>=this.R?!1:(this.merge(b.a,b.b),!0)},a.prototype.nEdges=function(a,b){var c=a.incoming.intersection(b.incoming),d=a.outgoing.intersection(b.outgoing);return this.R-c.count()-d.count()},a.prototype.getGroupHierarchy=function(a){var c=this,d=[],f={};b(this.roots,f,d);var g=this.allEdges();return g.forEach(function(b){var f=c.modules[b.source],g=c.modules[b.target];a.push(new e("undefined"==typeof f.gid?b.source:d[f.gid],"undefined"==typeof g.gid?b.target:d[g.gid],b.type))}),d},a.prototype.allEdges=function(){var b=[];return a.getEdges(this.roots,b),b},a.getEdges=function(b,c){b.forAll(function(b){b.getEdges(c),a.getEdges(b.children,c)})},a}();a.Configuration=f;var g=function(){function a(a,b,c,d){"undefined"==typeof b&&(b=new i),"undefined"==typeof c&&(c=new i),"undefined"==typeof d&&(d=new h),this.id=a,this.outgoing=b,this.incoming=c,this.children=d}return a.prototype.getEdges=function(a){var b=this;this.outgoing.forAll(function(c,d){c.forAll(function(c){a.push(new e(b.id,c.id,d))})})},a.prototype.isLeaf=function(){return 0===this.children.count()},a.prototype.isIsland=function(){return 0===this.outgoing.count()&&0===this.incoming.count()},a}();a.Module=g;var h=function(){function a(){this.table={}}return a.prototype.count=function(){return Object.keys(this.table).length},a.prototype.intersection=function(b){var d=new a;return d.table=c(this.table,b.table),d},a.prototype.intersectionCount=function(a){return this.intersection(a).count()},a.prototype.contains=function(a){return a in this.table},a.prototype.add=function(a){this.table[a.id]=a},a.prototype.remove=function(a){delete this.table[a.id]},a.prototype.forAll=function(a){for(var b in this.table)a(this.table[b])},a.prototype.modules=function(){var a=[];return this.forAll(function(b){return a.push(b)}),a},a}();a.ModuleSet=h;var i=function(){function a(){this.sets={},this.n=0}return a.prototype.count=function(){return this.n},a.prototype.contains=function(a){var b=!1;return this.forAllModules(function(c){b||c.id!=a||(b=!0)}),b},a.prototype.add=function(a,b){var c=a in this.sets?this.sets[a]:this.sets[a]=new h;c.add(b),++this.n},a.prototype.remove=function(a,b){var c=this.sets[a];c.remove(b),0===c.count()&&delete this.sets[a],--this.n},a.prototype.forAll=function(a){for(var b in this.sets)a(this.sets[b],b)},a.prototype.forAllModules=function(a){this.forAll(function(b){return b.forAll(a)})},a.prototype.intersection=function(b){var c=new a;return this.forAll(function(a,d){if(d in b.sets){var e=a.intersection(b.sets[d]),f=e.count();f>0&&(c.sets[d]=e,c.n+=f)}}),c},a}();a.LinkSets=i,a.getGroups=d}(a.powergraph||(a.powergraph={}));a.powergraph}(cola||(cola={}));var PairingHeap=function(){function a(a){this.elem=a,this.subheaps=[]}return a.prototype.toString=function(a){for(var b="",c=!1,d=0;d<this.subheaps.length;++d){var e=this.subheaps[d];e.elem?(c&&(b+=","),b+=e.toString(a),c=!0):c=!1}return""!==b&&(b="("+b+")"),(this.elem?a(this.elem):"")+b},a.prototype.forEach=function(a){this.empty()||(a(this.elem,this),this.subheaps.forEach(function(b){return b.forEach(a)}))},a.prototype.count=function(){return this.empty()?0:1+this.subheaps.reduce(function(a,b){return a+b.count()},0)},a.prototype.min=function(){return this.elem},a.prototype.empty=function(){return null==this.elem},a.prototype.contains=function(a){if(this===a)return!0;for(var b=0;b<this.subheaps.length;b++)if(this.subheaps[b].contains(a))return!0;return!1},a.prototype.isHeap=function(a){var b=this;return this.subheaps.every(function(c){return a(b.elem,c.elem)&&c.isHeap(a)})},a.prototype.insert=function(b,c){return this.merge(new a(b),c)},a.prototype.merge=function(a,b){return this.empty()?a:a.empty()?this:b(this.elem,a.elem)?(this.subheaps.push(a),this):(a.subheaps.push(this),a)},a.prototype.removeMin=function(a){return this.empty()?null:this.mergePairs(a)},a.prototype.mergePairs=function(b){if(0==this.subheaps.length)return new a(null);if(1==this.subheaps.length)return this.subheaps[0];var c=this.subheaps.pop().merge(this.subheaps.pop(),b),d=this.mergePairs(b);return c.merge(d,b)},a.prototype.decreaseKey=function(b,c,d,e){var f=b.removeMin(e);b.elem=f.elem,b.subheaps=f.subheaps,null!==d&&null!==f.elem&&d(b.elem,b);var g=new a(c);return null!==d&&d(c,g),this.merge(g,e)},a}(),PriorityQueue=function(){function a(a){this.lessThan=a}return a.prototype.top=function(){return this.empty()?null:this.root.elem},a.prototype.push=function(){for(var a=[],b=0;b<arguments.length-0;b++)a[b]=arguments[b+0];for(var c,d,e=0;d=a[e];++e)c=new PairingHeap(d),this.root=this.empty()?c:this.root.merge(c,this.lessThan);return c},a.prototype.empty=function(){return!this.root||!this.root.elem},a.prototype.isHeap=function(){return this.root.isHeap(this.lessThan)},a.prototype.forEach=function(a){this.root.forEach(a)},a.prototype.pop=function(){if(this.empty())return null;var a=this.root.min();return this.root=this.root.removeMin(this.lessThan),a},a.prototype.reduceKey=function(a,b,c){"undefined"==typeof c&&(c=null),this.root=this.root.decreaseKey(a,b,c,this.lessThan)},a.prototype.toString=function(a){return this.root.toString(a)},a.prototype.count=function(){return this.root.count()},a}(),cola;!function(a){!function(a){var b=function(){function a(a){this.scale=a,this.AB=0,this.AD=0,this.A2=0}return a.prototype.addVariable=function(a){var b=this.scale/a.scale,c=a.offset/a.scale,d=a.weight;this.AB+=d*b*c,this.AD+=d*b*a.desiredPosition,this.A2+=d*b*b},a.prototype.getPosn=function(){return(this.AD-this.AB)/this.A2},a}();a.PositionStats=b;var c=function(){function a(a,b,c,d){"undefined"==typeof d&&(d=!1),this.left=a,this.right=b,this.gap=c,this.equality=d,this.active=!1,this.unsatisfiable=!1,this.left=a,this.right=b,this.gap=c,this.equality=d}return a.prototype.slack=function(){return this.unsatisfiable?Number.MAX_VALUE:this.right.scale*this.right.position()-this.gap-this.left.scale*this.left.position()},a}();a.Constraint=c;var d=function(){function a(a,b,c){"undefined"==typeof b&&(b=1),"undefined"==typeof c&&(c=1),this.desiredPosition=a,this.weight=b,this.scale=c,this.offset=0}return a.prototype.dfdv=function(){return 2*this.weight*(this.position()-this.desiredPosition)},a.prototype.position=function(){return(this.block.ps.scale*this.block.posn+this.offset)/this.scale},a.prototype.visitNeighbours=function(a,b){var c=function(c,d){return c.active&&a!==d&&b(c,d)};this.cOut.forEach(function(a){return c(a,a.right)}),this.cIn.forEach(function(a){return c(a,a.left)})},a}();a.Variable=d;var e=function(){function a(a){this.vars=[],a.offset=0,this.ps=new b(a.scale),this.addVariable(a)}return a.prototype.addVariable=function(a){a.block=this,this.vars.push(a),this.ps.addVariable(a),this.posn=this.ps.getPosn()},a.prototype.updateWeightedPosition=function(){this.ps.AB=this.ps.AD=this.ps.A2=0;for(var a=0,b=this.vars.length;b>a;++a)this.ps.addVariable(this.vars[a]);this.posn=this.ps.getPosn()},a.prototype.compute_lm=function(a,b,c){var d=this,e=a.dfdv();return a.visitNeighbours(b,function(b,f){var g=d.compute_lm(f,a,c);f===b.right?(e+=g*b.left.scale,b.lm=g):(e+=g*b.right.scale,b.lm=-g),c(b)}),e/a.scale},a.prototype.populateSplitBlock=function(a,b){var c=this;a.visitNeighbours(b,function(b,d){d.offset=a.offset+(d===b.right?b.gap:-b.gap),c.addVariable(d),c.populateSplitBlock(d,a)})},a.prototype.traverse=function(a,b,c,d){var e=this;"undefined"==typeof c&&(c=this.vars[0]),"undefined"==typeof d&&(d=null),c.visitNeighbours(d,function(d,f){b.push(a(d)),e.traverse(a,b,f,c)})},a.prototype.findMinLM=function(){var a=null;return this.compute_lm(this.vars[0],null,function(b){!b.equality&&(null===a||b.lm<a.lm)&&(a=b)}),a},a.prototype.findMinLMBetween=function(a,b){this.compute_lm(a,null,function(){});var c=null;return this.findPath(a,null,b,function(a,b){!a.equality&&a.right===b&&(null===c||a.lm<c.lm)&&(c=a)}),c},a.prototype.findPath=function(a,b,c,d){var e=this,f=!1;return a.visitNeighbours(b,function(b,g){f||g!==c&&!e.findPath(g,a,c,d)||(f=!0,d(b,g))}),f},a.prototype.isActiveDirectedPathBetween=function(a,b){if(a===b)return!0;for(var c=a.cOut.length;c--;){var d=a.cOut[c];if(d.active&&this.isActiveDirectedPathBetween(d.right,b))return!0}return!1},a.split=function(b){return b.active=!1,[a.createSplitBlock(b.left),a.createSplitBlock(b.right)]},a.createSplitBlock=function(b){var c=new a(b);return c.populateSplitBlock(b,null),c},a.prototype.splitBetween=function(b,c){var d=this.findMinLMBetween(b,c);if(null!==d){var e=a.split(d);return{constraint:d,lb:e[0],rb:e[1]}}return null},a.prototype.mergeAcross=function(a,b,c){b.active=!0;for(var d=0,e=a.vars.length;e>d;++d){var f=a.vars[d];f.offset+=c,this.addVariable(f)}this.posn=this.ps.getPosn()},a.prototype.cost=function(){for(var a=0,b=this.vars.length;b--;){var c=this.vars[b],d=c.position()-c.desiredPosition;a+=d*d*c.weight}return a},a}();a.Block=e;var f=function(){function a(a){this.vs=a;var b=a.length;for(this.list=new Array(b);b--;){var c=new e(a[b]);this.list[b]=c,c.blockInd=b}}return a.prototype.cost=function(){for(var a=0,b=this.list.length;b--;)a+=this.list[b].cost();return a},a.prototype.insert=function(a){a.blockInd=this.list.length,this.list.push(a)},a.prototype.remove=function(a){var b=this.list.length-1,c=this.list[b];this.list.length=b,a!==c&&(this.list[a.blockInd]=c,c.blockInd=a.blockInd)},a.prototype.merge=function(a){var b=a.left.block,c=a.right.block,d=a.right.offset-a.left.offset-a.gap;b.vars.length<c.vars.length?(c.mergeAcross(b,a,d),this.remove(b)):(b.mergeAcross(c,a,-d),this.remove(c))},a.prototype.forEach=function(a){this.list.forEach(a)},a.prototype.updateBlockPositions=function(){this.list.forEach(function(a){return a.updateWeightedPosition()})},a.prototype.split=function(a){var b=this;this.updateBlockPositions(),this.list.forEach(function(c){var d=c.findMinLM();null!==d&&d.lm<g.LAGRANGIAN_TOLERANCE&&(c=d.left.block,e.split(d).forEach(function(a){return b.insert(a)}),b.remove(c),a.push(d))})},a}();a.Blocks=f;var g=function(){function a(a,b){this.vs=a,this.cs=b,this.vs=a,a.forEach(function(a){a.cIn=[],a.cOut=[]}),this.cs=b,b.forEach(function(a){a.left.cOut.push(a),a.right.cIn.push(a)}),this.inactive=b.map(function(a){return a.active=!1,a}),this.bs=null}return a.prototype.cost=function(){return this.bs.cost()},a.prototype.setStartingPositions=function(a){this.inactive=this.cs.map(function(a){return a.active=!1,a}),this.bs=new f(this.vs),this.bs.forEach(function(b,c){return b.posn=a[c]})},a.prototype.setDesiredPositions=function(a){this.vs.forEach(function(b,c){return b.desiredPosition=a[c]})},a.prototype.mostViolated=function(){for(var b=Number.MAX_VALUE,c=null,d=this.inactive,e=d.length,f=e,g=0;e>g;++g){var h=d[g];if(!h.unsatisfiable){var i=h.slack();if((h.equality||b>i)&&(b=i,c=h,f=g,h.equality))break}}return f!==e&&(b<a.ZERO_UPPERBOUND&&!c.active||c.equality)&&(d[f]=d[e-1],d.length=e-1),c},a.prototype.satisfy=function(){null==this.bs&&(this.bs=new f(this.vs)),this.bs.split(this.inactive);for(var b=null;(b=this.mostViolated())&&(b.equality||b.slack()<a.ZERO_UPPERBOUND&&!b.active);){var c=b.left.block,d=b.right.block;if(c!==d)this.bs.merge(b);else{if(c.isActiveDirectedPathBetween(b.right,b.left)){b.unsatisfiable=!0;continue}var e=c.splitBetween(b.left,b.right);if(null===e){b.unsatisfiable=!0;continue}this.bs.insert(e.lb),this.bs.insert(e.rb),this.bs.remove(c),this.inactive.push(e.constraint),b.slack()>=0?this.inactive.push(b):this.bs.merge(b)}}},a.prototype.solve=function(){this.satisfy();for(var a=Number.MAX_VALUE,b=this.bs.cost();Math.abs(a-b)>1e-4;)this.satisfy(),a=b,b=this.bs.cost();return b},a.LAGRANGIAN_TOLERANCE=-1e-4,a.ZERO_UPPERBOUND=-1e-10,a}();a.Solver=g}(a.vpsc||(a.vpsc={}));a.vpsc}(cola||(cola={}));var cola;!function(a){!function(b){function c(a){return a.bounds="undefined"!=typeof a.leaves?a.leaves.reduce(function(a,b){return b.bounds.union(a)},q.empty()):q.empty(),"undefined"!=typeof a.groups&&(a.bounds=a.groups.reduce(function(a,b){return c(b).union(a)},a.bounds)),a.bounds=a.bounds.inflate(a.padding),a.bounds}function d(a,b,c,d){var e=b.rayIntersection(c.cx(),c.cy());e||(e={x:b.cx(),y:b.cy()});var f=c.rayIntersection(b.cx(),b.cy());f||(f={x:c.cx(),y:c.cy()});var g=f.x-e.x,h=f.y-e.y,i=Math.sqrt(g*g+h*h),j=i-d;a.sourceIntersection=e,a.targetIntersection=f,a.arrowStart={x:e.x+j*g/i,y:e.y+j*h/i}}function e(a,b,c){var d=b.rayIntersection(a.x,a.y);d||(d={x:b.cx(),y:b.cy()});var e=d.x-a.x,f=d.y-a.y,g=Math.sqrt(e*e+f*f);return{x:d.x-c*e/g,y:d.y-c*f/g}}function f(a,b){return a.pos>b.pos?1:a.pos<b.pos?-1:a.isOpen?-1:0}function g(){return new RBTree(function(a,b){return a.pos-b.pos})}function h(a,b,c,d){"undefined"==typeof d&&(d=!1);var e=a.padding,f="undefined"!=typeof a.groups?a.groups.length:0,g="undefined"!=typeof a.leaves?a.leaves.length:0,j=f?a.groups.reduce(function(a,d){return a.concat(h(d,b,c,!0))},[]):[],k=(d?2:0)+g+f,l=new Array(k),m=new Array(k),n=0,o=function(a,b){m[n]=a,l[n++]=b};if(d){var p=a.bounds,q=b.getCentre(p),r=b.getSize(p)/2,s=b.getOpen(p),t=b.getClose(p),u=q-r+e/2,v=q+r-e/2;a.minVar.desiredPosition=u,o(b.makeRect(s,t,u,e),a.minVar),a.maxVar.desiredPosition=v,o(b.makeRect(s,t,v,e),a.maxVar)}g&&a.leaves.forEach(function(a){return o(a.bounds,a.variable)}),f&&a.groups.forEach(function(a){var c=a.bounds;o(b.makeRect(b.getOpen(c),b.getClose(c),b.getCentre(c),b.getSize(c)),a.minVar)});var w=i(m,l,b,c);return f&&(l.forEach(function(a){a.cOut=[],a.cIn=[]}),w.forEach(function(a){a.left.cOut.push(a),a.right.cIn.push(a)}),a.groups.forEach(function(a){var c=(a.padding-b.getSize(a.bounds))/2;a.minVar.cIn.forEach(function(a){return a.gap+=c}),a.minVar.cOut.forEach(function(b){b.left=a.maxVar,b.gap+=c})})),j.concat(w)}function i(b,c,d,e){var h,i=b.length,j=2*i;console.assert(c.length>=i);var k=new Array(j);for(h=0;i>h;++h){var l=b[h],m=new r(c[h],l,d.getCentre(l));k[h]=new s(!0,m,d.getOpen(l)),k[h+i]=new s(!1,m,d.getClose(l))}k.sort(f);var n=new Array,o=g();for(h=0;j>h;++h){var p=k[h],m=p.v;if(p.isOpen)o.insert(m),d.findNeighbours(m,o);else{o.remove(m);var q=function(b,c){var f=(d.getSize(b.r)+d.getSize(c.r))/2+e;n.push(new a.vpsc.Constraint(b.v,c.v,f))},t=function(a,b,c){for(var d,e=m[a].iterator();null!==(d=e[a]());)c(d,m),d[b].remove(m)};t("prev","next",function(a,b){return q(a,b)}),t("next","prev",function(a,b){return q(b,a)})}}return console.assert(0===o.size),n}function j(a,b){var c=function(c,d){for(var e,f=b.findIter(a);null!==(e=f[c]());){var g=e.r.overlapX(a.r);if((0>=g||g<=e.r.overlapY(a.r))&&(a[c].insert(e),e[d].insert(a)),0>=g)break}};c("next","prev"),c("prev","next")}function k(a,b){var c=function(c,d){var e=b.findIter(a)[c]();null!==e&&e.r.overlapX(a.r)>0&&(a[c].insert(e),e[d].insert(a))};c("next","prev"),c("prev","next")}function l(a,b){return i(a,b,t,1e-6)}function m(a,b){return i(a,b,u,1e-6)}function n(a){return h(a,t,1e-6)}function o(a){return h(a,u,1e-6)}function p(b){var c=b.map(function(b){return new a.vpsc.Variable(b.cx())}),d=a.vpsc.generateXConstraints(b,c),e=new a.vpsc.Solver(c,d);e.solve(),c.forEach(function(a,c){return b[c].setXCentre(a.position())}),c=b.map(function(b){return new a.vpsc.Variable(b.cy())}),d=a.vpsc.generateYConstraints(b,c),e=new a.vpsc.Solver(c,d),e.solve(),c.forEach(function(a,c){return b[c].setYCentre(a.position())})}b.computeGroupBounds=c;var q=function(){function a(a,b,c,d){this.x=a,this.X=b,this.y=c,this.Y=d}return a.empty=function(){return new a(Number.POSITIVE_INFINITY,Number.NEGATIVE_INFINITY,Number.POSITIVE_INFINITY,Number.NEGATIVE_INFINITY)},a.prototype.cx=function(){return(this.x+this.X)/2},a.prototype.cy=function(){return(this.y+this.Y)/2},a.prototype.overlapX=function(a){var b=this.cx(),c=a.cx();return c>=b&&a.x<this.X?this.X-a.x:b>=c&&this.x<a.X?a.X-this.x:0},a.prototype.overlapY=function(a){var b=this.cy(),c=a.cy();return c>=b&&a.y<this.Y?this.Y-a.y:b>=c&&this.y<a.Y?a.Y-this.y:0},a.prototype.setXCentre=function(a){var b=a-this.cx();this.x+=b,this.X+=b},a.prototype.setYCentre=function(a){var b=a-this.cy();this.y+=b,this.Y+=b},a.prototype.width=function(){return this.X-this.x},a.prototype.height=function(){return this.Y-this.y},a.prototype.union=function(b){return new a(Math.min(this.x,b.x),Math.max(this.X,b.X),Math.min(this.y,b.y),Math.max(this.Y,b.Y))},a.prototype.lineIntersections=function(b,c,d,e){for(var f=[[this.x,this.y,this.X,this.y],[this.X,this.y,this.X,this.Y],[this.X,this.Y,this.x,this.Y],[this.x,this.Y,this.x,this.y]],g=[],h=0;4>h;++h){var i=a.lineIntersection(b,c,d,e,f[h][0],f[h][1],f[h][2],f[h][3]);null!==i&&g.push({x:i.x,y:i.y})}return g},a.prototype.rayIntersection=function(a,b){var c=this.lineIntersections(this.cx(),this.cy(),a,b);return c.length>0?c[0]:null},a.prototype.vertices=function(){return[{x:this.x,y:this.y},{x:this.X,y:this.y},{x:this.X,y:this.Y},{x:this.x,y:this.Y},{x:this.x,y:this.y}]},a.lineIntersection=function(a,b,c,d,e,f,g,h){var i=c-a,j=g-e,k=d-b,l=h-f,m=l*i-j*k;if(0==m)return null;var n=a-e,o=b-f,p=j*o-l*n,q=p/m,r=i*o-k*n,s=r/m;return q>=0&&1>=q&&s>=0&&1>=s?{x:a+q*i,y:b+q*k}:null},a.prototype.inflate=function(b){return new a(this.x-b,this.X+b,this.y-b,this.Y+b)},a}();b.Rectangle=q,b.makeEdgeBetween=d,b.makeEdgeTo=e;var r=function(){function a(a,b,c){this.v=a,this.r=b,this.pos=c,this.prev=g(),this.next=g()}return a}(),s=function(){function a(a,b,c){this.isOpen=a,this.v=b,this.pos=c}return a}(),t={getCentre:function(a){return a.cx()},getOpen:function(a){return a.y},getClose:function(a){return a.Y},getSize:function(a){return a.width()},makeRect:function(a,b,c,d){return new q(c-d/2,c+d/2,a,b)},findNeighbours:j},u={getCentre:function(a){return a.cy()},getOpen:function(a){return a.x},getClose:function(a){return a.X},getSize:function(a){return a.height()},makeRect:function(a,b,c,d){return new q(a,b,c-d/2,c+d/2)},findNeighbours:k};b.generateXConstraints=l,b.generateYConstraints=m,b.generateXGroupConstraints=n,b.generateYGroupConstraints=o,b.removeOverlaps=p;var v=function(a){function b(b,c){a.call(this,0,c),this.index=b}return __extends(b,a),b}(a.vpsc.Variable),w=function(){function b(b,d,e,f,g){"undefined"==typeof e&&(e=null),"undefined"==typeof f&&(f=null),"undefined"==typeof g&&(g=!1);
-var h=this;if(this.nodes=b,this.groups=d,this.rootGroup=e,this.avoidOverlaps=g,this.variables=b.map(function(a,b){return a.variable=new v(b,1)}),f&&this.createConstraints(f),g&&e&&"undefined"!=typeof e.groups){b.forEach(function(b){if(!b.width||!b.height)return void(b.bounds=new a.vpsc.Rectangle(b.x,b.x,b.y,b.y));var c=b.width/2,d=b.height/2;b.bounds=new a.vpsc.Rectangle(b.x-c,b.x+c,b.y-d,b.y+d)}),c(e);var i=b.length;d.forEach(function(a){h.variables[i]=a.minVar=new v(i++,.01),h.variables[i]=a.maxVar=new v(i++,.01)})}}return b.prototype.createSeparation=function(b){return new a.vpsc.Constraint(this.nodes[b.left].variable,this.nodes[b.right].variable,b.gap,"undefined"!=typeof b.equality?b.equality:!1)},b.prototype.makeFeasible=function(a){var b=this;if(this.avoidOverlaps){var c="x",d="width";"x"===a.axis&&(c="y",d="height");var e=a.offsets.map(function(a){return b.nodes[a.node]}).sort(function(a,b){return a[c]-b[c]}),f=null;e.forEach(function(a){f&&(a[c]=f[c]+f[d]+1),f=a})}},b.prototype.createAlignment=function(b){var c=this,d=this.nodes[b.offsets[0].node].variable;this.makeFeasible(b);var e="x"===b.axis?this.xConstraints:this.yConstraints;b.offsets.slice(1).forEach(function(b){var f=c.nodes[b.node].variable;e.push(new a.vpsc.Constraint(d,f,b.offset,!0))})},b.prototype.createConstraints=function(a){var b=this,c=function(a){return"undefined"==typeof a.type||"separation"===a.type};this.xConstraints=a.filter(function(a){return"x"===a.axis&&c(a)}).map(function(a){return b.createSeparation(a)}),this.yConstraints=a.filter(function(a){return"y"===a.axis&&c(a)}).map(function(a){return b.createSeparation(a)}),a.filter(function(a){return"alignment"===a.type}).forEach(function(a){return b.createAlignment(a)})},b.prototype.setupVariablesAndBounds=function(a,b,c,d){this.nodes.forEach(function(e,f){e.fixed?(e.variable.weight=1e3,c[f]=d(e)):e.variable.weight=1;var g=(e.width||0)/2,h=(e.height||0)/2,i=a[f],j=b[f];e.bounds=new q(i-g,i+g,j-h,j+h)})},b.prototype.xProject=function(a,b,c){(this.rootGroup||this.avoidOverlaps||this.xConstraints)&&this.project(a,b,a,c,function(a){return a.px},this.xConstraints,n,function(a){return a.bounds.setXCentre(c[a.variable.index]=a.variable.position())},function(a){var b=c[a.minVar.index]=a.minVar.position(),d=c[a.maxVar.index]=a.maxVar.position(),e=a.padding/2;a.bounds.x=b-e,a.bounds.X=d+e})},b.prototype.yProject=function(a,b,c){(this.rootGroup||this.yConstraints)&&this.project(a,b,b,c,function(a){return a.py},this.yConstraints,o,function(a){return a.bounds.setYCentre(c[a.variable.index]=a.variable.position())},function(a){var b=c[a.minVar.index]=a.minVar.position(),d=c[a.maxVar.index]=a.maxVar.position(),e=a.padding/2;a.bounds.y=b-e,a.bounds.Y=d+e})},b.prototype.projectFunctions=function(){var a=this;return[function(b,c,d){return a.xProject(b,c,d)},function(b,c,d){return a.yProject(b,c,d)}]},b.prototype.project=function(a,b,d,e,f,g,h,i,j){this.setupVariablesAndBounds(a,b,e,f),this.rootGroup&&this.avoidOverlaps&&(c(this.rootGroup),g=g.concat(h(this.rootGroup))),this.solve(this.variables,g,d,e),this.nodes.forEach(i),this.rootGroup&&this.avoidOverlaps&&this.groups.forEach(j)},b.prototype.solve=function(b,c,d,e){var f=new a.vpsc.Solver(b,c);f.setStartingPositions(d),f.setDesiredPositions(e),f.solve()},b}();b.Projection=w}(a.vpsc||(a.vpsc={}));a.vpsc}(cola||(cola={}));var cola;!function(a){!function(a){var b=function(){function a(a,b){this.id=a,this.distance=b}return a}(),c=function(){function a(a){this.id=a,this.neighbours=[]}return a}(),d=function(){function a(a,d,e,f,g){this.n=a,this.es=d,this.neighbours=new Array(this.n);for(var h=this.n;h--;)this.neighbours[h]=new c(h);for(h=this.es.length;h--;){var i=this.es[h],j=e(i),k=f(i),l=g(i);this.neighbours[j].neighbours.push(new b(k,l)),this.neighbours[k].neighbours.push(new b(j,l))}}return a.prototype.DistanceMatrix=function(){for(var a=new Array(this.n),b=0;b<this.n;++b)a[b]=this.dijkstraNeighbours(b);return a},a.prototype.DistancesFromNode=function(a){return this.dijkstraNeighbours(a)},a.prototype.PathFromNodeToNode=function(a,b){return this.dijkstraNeighbours(a,b)},a.prototype.dijkstraNeighbours=function(a,b){"undefined"==typeof b&&(b=-1);for(var c=new PriorityQueue(function(a,b){return a.d<=b.d}),d=this.neighbours.length,e=new Array(d);d--;){var f=this.neighbours[d];f.d=d===a?0:Number.POSITIVE_INFINITY,f.q=c.push(f)}for(;!c.empty();){var g=c.pop();if(e[g.id]=g.d,g.id===b){for(var h=[],i=g;"undefined"!=typeof i.prev;)h.push(i.prev.id),i=i.prev;return h}for(d=g.neighbours.length;d--;){var j=g.neighbours[d],i=this.neighbours[j.id],k=g.d+j.distance;g.d!==Number.MAX_VALUE&&i.d>k&&(i.d=k,i.prev=g,c.reduceKey(i.q,i,function(a,b){return a.q=b}))}}return e},a}();a.Calculator=d}(a.shortestpaths||(a.shortestpaths={}));a.shortestpaths}(cola||(cola={}));var cola;!function(a){function b(a){a.fixed|=2,a.px=a.x,a.py=a.y}function c(a){a.fixed&=-7}return a.d3adaptor=function(){function d(a){return"function"==typeof s?+s.call(null,a):s}function e(a,b){a.length=b}function f(a){return"function"==typeof t?t(a):0}function g(a){return a}function h(a){return"number"==typeof a.source?a.source:a.source.index}function j(a){return"number"==typeof a.target?a.target:a.target.index}function k(a){a.px=d3.event.x,a.py=d3.event.y,p.resume()}var l,m,n,p={},q=d3.dispatch("start","tick","end"),r=[1,1],s=20,t=null,u=!1,v=!0,w=!1,x=[],y=[],z=[],A=null,B=[],C=[],D=null,E=null,F=null,G=.01,H=10,I=null;p.tick=function(){if(G>m)return q.end({type:"end",alpha:m=0}),delete n,w=!1,!0;{var a,b=x.length;B.length}for(E.locks.clear(),i=0;b>i;++i)if(a=x[i],a.fixed){("undefined"==typeof a.px||"undefined"==typeof a.py)&&(a.px=a.x,a.py=a.y);var c=[a.px,a.py];E.locks.add(i,c)}var d=E.rungeKutta();for(0===d?m=0:"undefined"!=typeof n&&(m=Math.abs(Math.abs(n/d)-1)),n=d,i=0;b>i;++i)a=x[i],a.fixed?(a.x=a.px,a.y=a.py):(a.x=E.x[0][i],a.y=E.x[1][i]);q.tick({type:"tick",alpha:m})},p.nodes=function(a){if(!arguments.length){if(0===x.length&&B.length>0){var b=0;B.forEach(function(a){b=Math.max(b,a.source,a.target)}),x=new Array(++b);for(var c=0;b>c;++c)x[c]={}}return x}return x=a,p},p.groups=function(a){return arguments.length?(y=a,A={},y.forEach(function(a){"undefined"==typeof a.padding&&(a.padding=1),"undefined"!=typeof a.leaves&&a.leaves.forEach(function(b,c){(a.leaves[c]=x[b]).parent=a}),"undefined"!=typeof a.groups&&a.groups.forEach(function(b,c){(a.groups[c]=y[b]).parent=a})}),A.leaves=x.filter(function(a){return"undefined"==typeof a.parent}),A.groups=y.filter(function(a){return"undefined"==typeof a.parent}),p):y},p.powerGraphGroups=function(b){var c=a.powergraph.getGroups(x,B,J);return this.groups(c.groups),b(c),p},p.avoidOverlaps=function(a){return arguments.length?(u=a,p):u},p.handleDisconnected=function(a){return arguments.length?(v=a,p):v},p.flowLayout=function(a,b){return arguments.length||(a="y"),F={axis:a,getMinSeparation:"number"==typeof b?function(){return b}:b},p},p.links=function(a){return arguments.length?(B=a,p):B},p.constraints=function(a){return arguments.length?(C=a,p):C},p.distanceMatrix=function(a){return arguments.length?(D=a,p):D},p.size=function(a){return arguments.length?(r=a,p):r},p.defaultNodeSize=function(a){return arguments.length?(H=a,p):H},p.linkDistance=function(a){return arguments.length?(s="function"==typeof a?a:+a,p):"function"==typeof s?s():s},p.linkType=function(a){return t=a,p},p.convergenceThreshold=function(a){return arguments.length?(G="function"==typeof a?a:+a,p):G},p.alpha=function(a){return arguments.length?(a=+a,m?m=a>0?a:0:a>0&&(w||(w=!0,q.start({type:"start",alpha:m=a}),d3.timer(p.tick))),p):m};var J={getSourceIndex:h,getTargetIndex:j,setLength:e,getType:f};return p.symmetricDiffLinkLengths=function(b,c){return a.symmetricDiffLinkLengths(B,J,c),this.linkDistance(function(a){return b*a.length}),p},p.jaccardLinkLengths=function(b,c){return a.jaccardLinkLengths(B,J,c),this.linkDistance(function(a){return b*a.length}),p},p.start=function(){var b,c=this.nodes().length,e=c+2*y.length,f=(B.length,r[0]),g=r[1],i=new Array(e),k=new Array(e);z=new Array(e);var l=null,m=this.avoidOverlaps();x.forEach(function(a,b){a.index=b,"undefined"==typeof a.x&&(a.x=f/2,a.y=g/2),i[b]=a.x,k[b]=a.y});var n;D?n=D:(n=new a.shortestpaths.Calculator(e,B,h,j,d).DistanceMatrix(),l=a.Descent.createSquareMatrix(e,function(){return 2}),B.forEach(function(a){var b=h(a),c=j(a);l[b][c]=l[c][b]=1}));var q=a.Descent.createSquareMatrix(e,function(a,b){return n[a][b]});if(A&&"undefined"!=typeof A.groups){var b=c;y.forEach(function(){l[b][b+1]=l[b+1][b]=1e-6,q[b][b+1]=q[b+1][b]=.1,i[b]=0,k[b++]=0,i[b]=0,k[b++]=0})}else A={leaves:x,groups:[]};var s=C||[];F&&(J.getMinSeparation=F.getMinSeparation,s=s.concat(a.generateDirectedEdgeConstraints(c,B,F.axis,J)));var t=arguments.length>0?arguments[0]:0,u=arguments.length>1?arguments[1]:0,w=arguments.length>2?arguments[2]:0;for(this.avoidOverlaps(!1),E=new a.Descent([i,k],q),E.locks.clear(),b=0;c>b;++b)if(o=x[b],o.fixed){o.px=o.x,o.py=o.y;var I=[o.x,o.y];E.locks.add(b,I)}return E.threshold=G,E.run(t),s.length>0&&(E.project=new a.vpsc.Projection(x,y,A,s).projectFunctions()),E.run(u),this.avoidOverlaps(m),m&&(E.project=new a.vpsc.Projection(x,y,A,s,!0).projectFunctions()),E.G=l,E.run(w),B.forEach(function(a){"number"==typeof a.source&&(a.source=x[a.source]),"number"==typeof a.target&&(a.target=x[a.target])}),x.forEach(function(a,b){a.x=i[b],a.y=k[b]}),!D&&v&&(a.applyPacking(a.separateGraphs(x,B),f,g,H),x.forEach(function(a,b){E.x[0][b]=a.x,E.x[1][b]=a.y})),p.resume()},p.resume=function(){return p.alpha(.1)},p.stop=function(){return p.alpha(0)},p.prepareEdgeRouting=function(b){I=new a.geom.TangentVisibilityGraph(x.map(function(a){return a.bounds.inflate(-b).vertices()}))},p.routeEdge=function(b,c){var d=[];10===b.source.id&&11===b.target.id;var e=new a.geom.TangentVisibilityGraph(I.P,{V:I.V,E:I.E}),f={x:b.source.x,y:b.source.y},g={x:b.target.x,y:b.target.y},i=e.addPoint(f,b.source.id),k=e.addPoint(g,b.target.id);e.addEdgeIfVisible(f,g,b.source.id,b.target.id),"undefined"!=typeof c&&c(e);var l=function(a){return a.source.id},m=function(a){return a.target.id},n=function(a){return a.length()},o=new a.shortestpaths.Calculator(e.V.length,e.E,l,m,n),p=o.PathFromNodeToNode(i.id,k.id);if(1===p.length||p.length===e.V.length)a.vpsc.makeEdgeBetween(b,b.source.innerBounds,b.target.innerBounds,5),d=[{x:b.sourceIntersection.x,y:b.sourceIntersection.y},{x:b.arrowStart.x,y:b.arrowStart.y}];else{for(var q=p.length-2,r=e.V[p[q]].p,s=e.V[p[0]].p,d=[b.source.innerBounds.rayIntersection(r.x,r.y)],t=q;t>=0;--t)d.push(e.V[p[t]].p);d.push(a.vpsc.makeEdgeTo(s,b.target.innerBounds,5))}return d.forEach(function(a,c){if(c>0){var e=d[c-1];x.forEach(function(c){if(c.id!==h(b)&&c.id!==j(b)){var d=c.innerBounds.lineIntersections(e.x,e.y,a.x,a.y);d.length>0}})}}),d},p.drag=function(){return l||(l=d3.behavior.drag().origin(g).on("dragstart.d3adaptor",b).on("drag.d3adaptor",k).on("dragend.d3adaptor",c)),arguments.length?void this.call(l):l},p.linkId=function(a){return h(a)+"-"+j(a)},d3.rebind(p,q,"on")},a}(cola||(cola={})),RBTree=function(a){var b=function(a){var c=b.m[a];if(c.mod)return c.mod.exports;var d=c.mod={exports:{}};return c(d,d.exports),d.exports};return b.m={},b.m["./treebase"]=function(a){function b(){}function c(a){this._tree=a,this._ancestors=[],this._cursor=null}b.prototype.clear=function(){this._root=null,this.size=0},b.prototype.find=function(a){for(var b=this._root;null!==b;){var c=this._comparator(a,b.data);if(0===c)return b.data;b=b.get_child(c>0)}return null},b.prototype.findIter=function(a){for(var b=this._root,c=this.iterator();null!==b;){var d=this._comparator(a,b.data);if(0===d)return c._cursor=b,c;c._ancestors.push(b),b=b.get_child(d>0)}return null},b.prototype.lowerBound=function(a){return this._bound(a,this._comparator)},b.prototype.upperBound=function(a){function b(a,b){return c(b,a)}var c=this._comparator;return this._bound(a,b)},b.prototype.min=function(){var a=this._root;if(null===a)return null;for(;null!==a.left;)a=a.left;return a.data},b.prototype.max=function(){var a=this._root;if(null===a)return null;for(;null!==a.right;)a=a.right;return a.data},b.prototype.iterator=function(){return new c(this)},b.prototype.each=function(a){for(var b,c=this.iterator();null!==(b=c.next());)a(b)},b.prototype.reach=function(a){for(var b,c=this.iterator();null!==(b=c.prev());)a(b)},b.prototype._bound=function(a,b){for(var c=this._root,d=this.iterator();null!==c;){var e=this._comparator(a,c.data);if(0===e)return d._cursor=c,d;d._ancestors.push(c),c=c.get_child(e>0)}for(var f=d._ancestors.length-1;f>=0;--f)if(c=d._ancestors[f],b(a,c.data)>0)return d._cursor=c,d._ancestors.length=f,d;return d._ancestors.length=0,d},c.prototype.data=function(){return null!==this._cursor?this._cursor.data:null},c.prototype.next=function(){if(null===this._cursor){var a=this._tree._root;null!==a&&this._minNode(a)}else if(null===this._cursor.right){var b;do{if(b=this._cursor,!this._ancestors.length){this._cursor=null;break}this._cursor=this._ancestors.pop()}while(this._cursor.right===b)}else this._ancestors.push(this._cursor),this._minNode(this._cursor.right);return null!==this._cursor?this._cursor.data:null},c.prototype.prev=function(){if(null===this._cursor){var a=this._tree._root;null!==a&&this._maxNode(a)}else if(null===this._cursor.left){var b;do{if(b=this._cursor,!this._ancestors.length){this._cursor=null;break}this._cursor=this._ancestors.pop()}while(this._cursor.left===b)}else this._ancestors.push(this._cursor),this._maxNode(this._cursor.left);return null!==this._cursor?this._cursor.data:null},c.prototype._minNode=function(a){for(;null!==a.left;)this._ancestors.push(a),a=a.left;this._cursor=a},c.prototype._maxNode=function(a){for(;null!==a.right;)this._ancestors.push(a),a=a.right;this._cursor=a},a.exports=b},b.m.__main__=function(a){function c(a){this.data=a,this.left=null,this.right=null,this.red=!0}function d(a){this._root=null,this._comparator=a,this.size=0}function e(a){return null!==a&&a.red}function f(a,b){var c=a.get_child(!b);return a.set_child(!b,c.get_child(b)),c.set_child(b,a),a.red=!0,c.red=!1,c}function g(a,b){return a.set_child(!b,f(a.get_child(!b),!b)),f(a,b)}var h=b("./treebase");c.prototype.get_child=function(a){return a?this.right:this.left},c.prototype.set_child=function(a,b){a?this.right=b:this.left=b},d.prototype=new h,d.prototype.insert=function(a){var b=!1;if(null===this._root)this._root=new c(a),b=!0,this.size++;else{var d=new c(void 0),h=0,i=0,j=null,k=d,l=null,m=this._root;for(k.right=this._root;;){if(null===m?(m=new c(a),l.set_child(h,m),b=!0,this.size++):e(m.left)&&e(m.right)&&(m.red=!0,m.left.red=!1,m.right.red=!1),e(m)&&e(l)){var n=k.right===j;m===l.get_child(i)?k.set_child(n,f(j,!i)):k.set_child(n,g(j,!i))}var o=this._comparator(m.data,a);if(0===o)break;i=h,h=0>o,null!==j&&(k=j),j=l,l=m,m=m.get_child(h)}this._root=d.right}return this._root.red=!1,b},d.prototype.remove=function(a){if(null===this._root)return!1;var b=new c(void 0),d=b;d.right=this._root;for(var h=null,i=null,j=null,k=1;null!==d.get_child(k);){var l=k;i=h,h=d,d=d.get_child(k);var m=this._comparator(a,d.data);if(k=m>0,0===m&&(j=d),!e(d)&&!e(d.get_child(k)))if(e(d.get_child(!k))){var n=f(d,k);h.set_child(l,n),h=n}else if(!e(d.get_child(!k))){var o=h.get_child(!l);if(null!==o)if(e(o.get_child(!l))||e(o.get_child(l))){var p=i.right===h;e(o.get_child(l))?i.set_child(p,g(h,l)):e(o.get_child(!l))&&i.set_child(p,f(h,l));var q=i.get_child(p);q.red=!0,d.red=!0,q.left.red=!1,q.right.red=!1}else h.red=!1,o.red=!0,d.red=!0}}return null!==j&&(j.data=d.data,h.set_child(h.right===d,d.get_child(null===d.left)),this.size--),this._root=b.right,null!==this._root&&(this._root.red=!1),null!==j},a.exports=d},b("__main__")}(window);var cola;!function(a){var b={};return b.PADDING=10,b.GOLDEN_SECTION=(1+Math.sqrt(5))/2,b.FLOAT_EPSILON=1e-4,b.MAX_INERATIONS=100,a.applyPacking=function(a,c,d,e,f){function g(a){function b(a){var b=Number.MAX_VALUE,c=Number.MAX_VALUE,d=0,f=0;a.array.forEach(function(a){var g="undefined"!=typeof a.width?a.width:e,h="undefined"!=typeof a.height?a.height:e;g/=2,h/=2,d=Math.max(a.x+g,d),b=Math.min(a.x-g,b),f=Math.max(a.y+h,f),c=Math.min(a.y-h,c)}),a.width=d-b,a.height=f-c}a.forEach(function(a){b(a)})}function h(a){a.forEach(function(a){var b={x:0,y:0};a.array.forEach(function(a){b.x+=a.x,b.y+=a.y}),b.x/=a.array.length,b.y/=a.array.length;var c={x:b.x-a.width/2,y:b.y-a.height/2},d={x:a.x-c.x,y:a.y-c.y};a.array.forEach(function(a){a.x=a.x+d.x+p/2-r/2,a.y=a.y+d.y+q/2-s/2})})}function i(a){var c=Number.POSITIVE_INFINITY,d=0;a.sort(function(a,b){return b.height-a.height}),t=a.reduce(function(a,b){return a.width<b.width?a.width:b.width});for(var e=o=t,f=p=l(a),g=0,h=Number.MAX_VALUE,i=Number.MAX_VALUE,k=-1,m=Number.MAX_VALUE,n=Number.MAX_VALUE;m>t||n>b.FLOAT_EPSILON;){if(1!=k)var o=f-(f-e)/b.GOLDEN_SECTION,h=j(a,o);if(0!=k)var p=e+(f-e)/b.GOLDEN_SECTION,i=j(a,p);if(m=Math.abs(o-p),n=Math.abs(h-i),c>h&&(c=h,d=o),c>i&&(c=i,d=p),h>i?(e=o,o=p,h=i,k=1):(f=p,p=o,i=h,k=0),g++>100)break}j(a,d)}function j(a,b){v=[],r=0,s=0,u=o;for(var c=0;c<a.length;c++){var d=a[c];k(d,b)}return Math.abs(m()-f)}function k(a,c){for(var d=void 0,e=0;e<v.length;e++)if(v[e].space_left>=a.height&&v[e].x+v[e].width+a.width+b.PADDING-c<=b.FLOAT_EPSILON){d=v[e];break}v.push(a),void 0!==d?(a.x=d.x+d.width+b.PADDING,a.y=d.bottom,a.space_left=a.height,a.bottom=a.y,d.space_left-=a.height+b.PADDING,d.bottom+=a.height+b.PADDING):(a.y=u,u+=a.height+b.PADDING,a.x=n,a.bottom=a.y,a.space_left=a.height),a.y+a.height-s>-b.FLOAT_EPSILON&&(s=a.y+a.height-o),a.x+a.width-r>-b.FLOAT_EPSILON&&(r=a.x+a.width-n)}function l(a){var c=0;return a.forEach(function(a){return c+=a.width+b.PADDING}),c}function m(){return r/s}var n=0,o=0,p=c,q=d,f="undefined"!=typeof f?f:1,e="undefined"!=typeof e?e:0,r=0,s=0,t=0,u=0,v=[];0!=a.length&&(g(a),i(a),h(a))},a.separateGraphs=function(a,b){function c(a,b){if(void 0===d[a.index]){b&&(f++,graphs.push({array:[]})),d[a.index]=f,graphs[f-1].array.push(a);var g=e[a.index];if(g)for(var h=0;h<g.length;h++)c(g[h],!1)}}var d={},e={};graphs=[];for(var f=0,g=0;g<b.length;g++){var h=b[g],i=h.source,j=h.target;e[i.index]?e[i.index].push(j):e[i.index]=[j],e[j.index]?e[j.index].push(i):e[j.index]=[i]}for(var g=0;g<a.length;g++){var k=a[g];d[k.index]||c(k,!0)}return graphs},a}(cola||(cola={}));
+var cola;
+(function (cola) {
+    var Locks = (function () {
+        function Locks() {
+            this.locks = {};
+        }
+        Locks.prototype.add = function (id, x) {
+            if (isNaN(x[0]) || isNaN(x[1]))
+                debugger;
+            this.locks[id] = x;
+        };
+
+        Locks.prototype.clear = function () {
+            this.locks = {};
+        };
+
+        Locks.prototype.isEmpty = function () {
+            for (var l in this.locks)
+                return false;
+            return true;
+        };
+
+        Locks.prototype.apply = function (f) {
+            for (var l in this.locks) {
+                f(l, this.locks[l]);
+            }
+        };
+        return Locks;
+    })();
+    cola.Locks = Locks;
+
+    var Descent = (function () {
+        function Descent(x, D, G) {
+            if (typeof G === "undefined") { G = null; }
+            this.D = D;
+            this.G = G;
+            this.threshold = 0.0001;
+            this.random = new PseudoRandom();
+            this.project = null;
+            this.x = x;
+            this.k = x.length;
+            var n = this.n = x[0].length;
+            this.H = new Array(this.k);
+            this.g = new Array(this.k);
+            this.Hd = new Array(this.k);
+            this.a = new Array(this.k);
+            this.b = new Array(this.k);
+            this.c = new Array(this.k);
+            this.d = new Array(this.k);
+            this.e = new Array(this.k);
+            this.ia = new Array(this.k);
+            this.ib = new Array(this.k);
+            this.xtmp = new Array(this.k);
+            this.locks = new Locks();
+            this.minD = Number.MAX_VALUE;
+            var i = n, j;
+            while (i--) {
+                j = n;
+                while (--j > i) {
+                    var d = D[i][j];
+                    if (d > 0 && d < this.minD) {
+                        this.minD = d;
+                    }
+                }
+            }
+            if (this.minD === Number.MAX_VALUE)
+                this.minD = 1;
+            i = this.k;
+            while (i--) {
+                this.g[i] = new Array(n);
+                this.H[i] = new Array(n);
+                j = n;
+                while (j--) {
+                    this.H[i][j] = new Array(n);
+                }
+                this.Hd[i] = new Array(n);
+                this.a[i] = new Array(n);
+                this.b[i] = new Array(n);
+                this.c[i] = new Array(n);
+                this.d[i] = new Array(n);
+                this.e[i] = new Array(n);
+                this.ia[i] = new Array(n);
+                this.ib[i] = new Array(n);
+                this.xtmp[i] = new Array(n);
+            }
+        }
+        Descent.createSquareMatrix = function (n, f) {
+            var M = new Array(n);
+            for (var i = 0; i < n; ++i) {
+                M[i] = new Array(n);
+                for (var j = 0; j < n; ++j) {
+                    M[i][j] = f(i, j);
+                }
+            }
+            return M;
+        };
+
+        Descent.prototype.offsetDir = function () {
+            var _this = this;
+            var u = new Array(this.k);
+            var l = 0;
+            for (var i = 0; i < this.k; ++i) {
+                var x = u[i] = this.random.getNextBetween(0.01, 1) - 0.5;
+                l += x * x;
+            }
+            l = Math.sqrt(l);
+            return u.map(function (x) {
+                return x *= _this.minD / l;
+            });
+        };
+
+        Descent.prototype.computeDerivatives = function (x) {
+            var _this = this;
+            var n = this.n;
+            if (n < 1)
+                return;
+            var i;
+
+            var d = new Array(this.k);
+            var d2 = new Array(this.k);
+            var Huu = new Array(this.k);
+            var maxH = 0;
+            for (var u = 0; u < n; ++u) {
+                for (i = 0; i < this.k; ++i)
+                    Huu[i] = this.g[i][u] = 0;
+                for (var v = 0; v < n; ++v) {
+                    if (u === v)
+                        continue;
+                    while (true) {
+                        var sd2 = 0;
+                        for (i = 0; i < this.k; ++i) {
+                            var dx = d[i] = x[i][u] - x[i][v];
+                            sd2 += d2[i] = dx * dx;
+                        }
+                        if (sd2 > 1e-9)
+                            break;
+                        var rd = this.offsetDir();
+                        for (i = 0; i < this.k; ++i)
+                            x[i][v] += rd[i];
+                    }
+                    var l = Math.sqrt(sd2);
+                    var D = this.D[u][v];
+                    var weight = this.G != null ? this.G[u][v] : 1;
+                    if (weight > 1 && l > D || !isFinite(D)) {
+                        for (i = 0; i < this.k; ++i)
+                            this.H[i][u][v] = 0;
+                        continue;
+                    }
+                    if (weight > 1) {
+                        weight = 1;
+                    }
+                    var D2 = D * D;
+                    var gs = weight * (l - D) / (D2 * l);
+                    var hs = -weight / (D2 * l * l * l);
+                    if (!isFinite(gs))
+                        console.log(gs);
+                    for (i = 0; i < this.k; ++i) {
+                        this.g[i][u] += d[i] * gs;
+                        Huu[i] -= this.H[i][u][v] = hs * (D * (d2[i] - sd2) + l * sd2);
+                    }
+                }
+                for (i = 0; i < this.k; ++i)
+                    maxH = Math.max(maxH, this.H[i][u][u] = Huu[i]);
+            }
+            if (!this.locks.isEmpty()) {
+                this.locks.apply(function (u, p) {
+                    for (i = 0; i < _this.k; ++i) {
+                        _this.H[i][u][u] += maxH;
+                        _this.g[i][u] -= maxH * (p[i] - x[i][u]);
+                    }
+                });
+            }
+        };
+
+        Descent.dotProd = function (a, b) {
+            var x = 0, i = a.length;
+            while (i--)
+                x += a[i] * b[i];
+            return x;
+        };
+
+        Descent.rightMultiply = function (m, v, r) {
+            var i = m.length;
+            while (i--)
+                r[i] = Descent.dotProd(m[i], v);
+        };
+
+        Descent.prototype.computeStepSize = function (d) {
+            var numerator = 0, denominator = 0;
+            for (var i = 0; i < 2; ++i) {
+                numerator += Descent.dotProd(this.g[i], d[i]);
+                Descent.rightMultiply(this.H[i], d[i], this.Hd[i]);
+                denominator += Descent.dotProd(d[i], this.Hd[i]);
+            }
+            if (denominator === 0 || !isFinite(denominator))
+                return 0;
+            return numerator / denominator;
+        };
+
+        Descent.prototype.reduceStress = function () {
+            this.computeDerivatives(this.x);
+            var alpha = this.computeStepSize(this.g);
+            for (var i = 0; i < this.k; ++i) {
+                this.takeDescentStep(this.x[i], this.g[i], alpha);
+            }
+            return this.computeStress();
+        };
+
+        Descent.copy = function (a, b) {
+            var m = a.length, n = b[0].length;
+            for (var i = 0; i < m; ++i) {
+                for (var j = 0; j < n; ++j) {
+                    b[i][j] = a[i][j];
+                }
+            }
+        };
+
+        Descent.prototype.stepAndProject = function (x0, r, d, stepSize) {
+            Descent.copy(x0, r);
+            this.takeDescentStep(r[0], d[0], stepSize);
+            if (this.project)
+                this.project[0](x0[0], x0[1], r[0]);
+            this.takeDescentStep(r[1], d[1], stepSize);
+            if (this.project)
+                this.project[1](r[0], x0[1], r[1]);
+        };
+
+        Descent.mApply = function (m, n, f) {
+            var i = m;
+            while (i-- > 0) {
+                var j = n;
+                while (j-- > 0)
+                    f(i, j);
+            }
+        };
+        Descent.prototype.matrixApply = function (f) {
+            Descent.mApply(this.k, this.n, f);
+        };
+
+        Descent.prototype.computeNextPosition = function (x0, r) {
+            var _this = this;
+            this.computeDerivatives(x0);
+            var alpha = this.computeStepSize(this.g);
+            this.stepAndProject(x0, r, this.g, alpha);
+
+            for (var u = 0; u < this.n; ++u)
+                for (var i = 0; i < this.k; ++i)
+                    if (isNaN(r[i][u]))
+                        debugger;
+
+            if (this.project) {
+                this.matrixApply(function (i, j) {
+                    return _this.e[i][j] = x0[i][j] - r[i][j];
+                });
+                var beta = this.computeStepSize(this.e);
+                beta = Math.max(0.2, Math.min(beta, 1));
+                this.stepAndProject(x0, r, this.e, beta);
+            }
+        };
+
+        Descent.prototype.run = function (iterations) {
+            var stress = Number.MAX_VALUE, converged = false;
+            while (!converged && iterations-- > 0) {
+                var s = this.rungeKutta();
+                converged = Math.abs(stress / s - 1) < this.threshold;
+                stress = s;
+            }
+            return stress;
+        };
+
+        Descent.prototype.rungeKutta = function () {
+            var _this = this;
+            this.computeNextPosition(this.x, this.a);
+            Descent.mid(this.x, this.a, this.ia);
+            this.computeNextPosition(this.ia, this.b);
+            Descent.mid(this.x, this.b, this.ib);
+            this.computeNextPosition(this.ib, this.c);
+            this.computeNextPosition(this.c, this.d);
+            var disp = 0;
+            this.matrixApply(function (i, j) {
+                var x = (_this.a[i][j] + 2.0 * _this.b[i][j] + 2.0 * _this.c[i][j] + _this.d[i][j]) / 6.0, d = _this.x[i][j] - x;
+                disp += d * d;
+                _this.x[i][j] = x;
+            });
+            return disp;
+        };
+
+        Descent.mid = function (a, b, m) {
+            Descent.mApply(a.length, a[0].length, function (i, j) {
+                return m[i][j] = a[i][j] + (b[i][j] - a[i][j]) / 2.0;
+            });
+        };
+
+        Descent.prototype.takeDescentStep = function (x, d, stepSize) {
+            for (var i = 0; i < this.n; ++i) {
+                x[i] = x[i] - stepSize * d[i];
+            }
+        };
+
+        Descent.prototype.computeStress = function () {
+            var stress = 0;
+            for (var u = 0, nMinus1 = this.n - 1; u < nMinus1; ++u) {
+                for (var v = u + 1, n = this.n; v < n; ++v) {
+                    var l = 0;
+                    for (var i = 0; i < this.k; ++i) {
+                        var dx = this.x[i][u] - this.x[i][v];
+                        l += dx * dx;
+                    }
+                    l = Math.sqrt(l);
+                    var d = this.D[u][v];
+                    if (!isFinite(d))
+                        continue;
+                    var rl = d - l;
+                    var d2 = d * d;
+                    stress += rl * rl / d2;
+                }
+            }
+            return stress;
+        };
+        Descent.zeroDistance = 1e-10;
+        return Descent;
+    })();
+    cola.Descent = Descent;
+
+    var PseudoRandom = (function () {
+        function PseudoRandom(seed) {
+            if (typeof seed === "undefined") { seed = 1; }
+            this.seed = seed;
+            this.a = 214013;
+            this.c = 2531011;
+            this.m = 2147483648;
+            this.range = 32767;
+        }
+        PseudoRandom.prototype.getNext = function () {
+            this.seed = (this.seed * this.a + this.c) % this.m;
+            return (this.seed >> 16) / this.range;
+        };
+
+        PseudoRandom.prototype.getNextBetween = function (min, max) {
+            return min + this.getNext() * (max - min);
+        };
+        return PseudoRandom;
+    })();
+    cola.PseudoRandom = PseudoRandom;
+})(cola || (cola = {}));
+var __extends = this.__extends || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var cola;
+(function (cola) {
+    (function (geom) {
+        var Point = (function () {
+            function Point() {
+            }
+            return Point;
+        })();
+        geom.Point = Point;
+
+        var LineSegment = (function () {
+            function LineSegment(x1, y1, x2, y2) {
+                this.x1 = x1;
+                this.y1 = y1;
+                this.x2 = x2;
+                this.y2 = y2;
+            }
+            return LineSegment;
+        })();
+        geom.LineSegment = LineSegment;
+
+        var PolyPoint = (function (_super) {
+            __extends(PolyPoint, _super);
+            function PolyPoint() {
+                _super.apply(this, arguments);
+            }
+            return PolyPoint;
+        })(Point);
+        geom.PolyPoint = PolyPoint;
+
+        function isLeft(P0, P1, P2) {
+            return (P1.x - P0.x) * (P2.y - P0.y) - (P2.x - P0.x) * (P1.y - P0.y);
+        }
+        geom.isLeft = isLeft;
+
+        function above(p, vi, vj) {
+            return isLeft(p, vi, vj) > 0;
+        }
+
+        function below(p, vi, vj) {
+            return isLeft(p, vi, vj) < 0;
+        }
+
+        function ConvexHull(S) {
+            var P = S.slice(0).sort(function (a, b) {
+                return a.x !== b.x ? b.x - a.x : b.y - a.y;
+            });
+            var n = S.length, i;
+            var minmin = 0;
+            var xmin = P[0].x;
+            for (i = 1; i < n; ++i) {
+                if (P[i].x !== xmin)
+                    break;
+            }
+            var minmax = i - 1;
+            var H = [];
+            H.push(P[minmin]);
+            if (minmax === n - 1) {
+                if (P[minmax].y !== P[minmin].y)
+                    H.push(P[minmax]);
+            } else {
+                var maxmin, maxmax = n - 1;
+                var xmax = P[n - 1].x;
+                for (i = n - 2; i >= 0; i--)
+                    if (P[i].x !== xmax)
+                        break;
+                maxmin = i + 1;
+
+                i = minmax;
+                while (++i <= maxmin) {
+                    if (isLeft(P[minmin], P[maxmin], P[i]) >= 0 && i < maxmin)
+                        continue;
+
+                    while (H.length > 1) {
+                        if (isLeft(H[H.length - 2], H[H.length - 1], P[i]) > 0)
+                            break;
+                        else
+                            H.length -= 1;
+                    }
+                    if (i != minmin)
+                        H.push(P[i]);
+                }
+
+                if (maxmax != maxmin)
+                    H.push(P[maxmax]);
+                var bot = H.length;
+                i = maxmin;
+                while (--i >= minmax) {
+                    if (isLeft(P[maxmax], P[minmax], P[i]) >= 0 && i > minmax)
+                        continue;
+
+                    while (H.length > bot) {
+                        if (isLeft(H[H.length - 2], H[H.length - 1], P[i]) > 0)
+                            break;
+                        else
+                            H.length -= 1;
+                    }
+                    if (i != minmin)
+                        H.push(P[i]);
+                }
+            }
+            return H;
+        }
+        geom.ConvexHull = ConvexHull;
+
+        function clockwiseRadialSweep(p, P, f) {
+            P.slice(0).sort(function (a, b) {
+                return Math.atan2(a.y - p.y, a.x - p.x) - Math.atan2(b.y - p.y, b.x - p.x);
+            }).forEach(f);
+        }
+        geom.clockwiseRadialSweep = clockwiseRadialSweep;
+
+        function nextPolyPoint(p, ps) {
+            if (p.polyIndex === ps.length - 1)
+                return ps[0];
+            return ps[p.polyIndex + 1];
+        }
+
+        function prevPolyPoint(p, ps) {
+            if (p.polyIndex === 0)
+                return ps[ps.length - 1];
+            return ps[p.polyIndex - 1];
+        }
+
+        function tangent_PointPolyC(P, V) {
+            return { rtan: Rtangent_PointPolyC(P, V), ltan: Ltangent_PointPolyC(P, V) };
+        }
+
+        function Rtangent_PointPolyC(P, V) {
+            var n = V.length - 1;
+
+            var a, b, c;
+            var upA, dnC;
+
+            if (below(P, V[1], V[0]) && !above(P, V[n - 1], V[0]))
+                return 0;
+
+            for (a = 0, b = n; ;) {
+                if (b - a === 1)
+                    if (above(P, V[a], V[b]))
+                        return a;
+                    else
+                        return b;
+
+                c = Math.floor((a + b) / 2);
+                dnC = below(P, V[c + 1], V[c]);
+                if (dnC && !above(P, V[c - 1], V[c]))
+                    return c;
+
+                upA = above(P, V[a + 1], V[a]);
+                if (upA) {
+                    if (dnC)
+                        b = c;
+                    else {
+                        if (above(P, V[a], V[c]))
+                            b = c;
+                        else
+                            a = c;
+                    }
+                } else {
+                    if (!dnC)
+                        a = c;
+                    else {
+                        if (below(P, V[a], V[c]))
+                            b = c;
+                        else
+                            a = c;
+                    }
+                }
+            }
+        }
+
+        function Ltangent_PointPolyC(P, V) {
+            var n = V.length - 1;
+
+            var a, b, c;
+            var dnA, dnC;
+
+            if (above(P, V[n - 1], V[0]) && !below(P, V[1], V[0]))
+                return 0;
+
+            for (a = 0, b = n; ;) {
+                if (b - a === 1)
+                    if (below(P, V[a], V[b]))
+                        return a;
+                    else
+                        return b;
+
+                c = Math.floor((a + b) / 2);
+                dnC = below(P, V[c + 1], V[c]);
+                if (above(P, V[c - 1], V[c]) && !dnC)
+                    return c;
+
+                dnA = below(P, V[a + 1], V[a]);
+                if (dnA) {
+                    if (!dnC)
+                        b = c;
+                    else {
+                        if (below(P, V[a], V[c]))
+                            b = c;
+                        else
+                            a = c;
+                    }
+                } else {
+                    if (dnC)
+                        a = c;
+                    else {
+                        if (above(P, V[a], V[c]))
+                            b = c;
+                        else
+                            a = c;
+                    }
+                }
+            }
+        }
+
+        function tangent_PolyPolyC(V, W, t1, t2, cmp1, cmp2) {
+            var ix1, ix2;
+
+            ix1 = t1(W[0], V);
+            ix2 = t2(V[ix1], W);
+
+            var done = false;
+            while (!done) {
+                done = true;
+                while (true) {
+                    if (ix1 === V.length - 1)
+                        ix1 = 0;
+                    if (cmp1(W[ix2], V[ix1], V[ix1 + 1]))
+                        break;
+                    ++ix1;
+                }
+                while (true) {
+                    if (ix2 === 0)
+                        ix2 = W.length - 1;
+                    if (cmp2(V[ix1], W[ix2], W[ix2 - 1]))
+                        break;
+                    --ix2;
+                    done = false;
+                }
+            }
+            return { t1: ix1, t2: ix2 };
+        }
+        geom.tangent_PolyPolyC = tangent_PolyPolyC;
+
+        function LRtangent_PolyPolyC(V, W) {
+            var rl = RLtangent_PolyPolyC(W, V);
+            return { t1: rl.t2, t2: rl.t1 };
+        }
+        geom.LRtangent_PolyPolyC = LRtangent_PolyPolyC;
+
+        function RLtangent_PolyPolyC(V, W) {
+            return tangent_PolyPolyC(V, W, Rtangent_PointPolyC, Ltangent_PointPolyC, above, below);
+        }
+        geom.RLtangent_PolyPolyC = RLtangent_PolyPolyC;
+
+        function LLtangent_PolyPolyC(V, W) {
+            return tangent_PolyPolyC(V, W, Ltangent_PointPolyC, Ltangent_PointPolyC, below, below);
+        }
+        geom.LLtangent_PolyPolyC = LLtangent_PolyPolyC;
+
+        function RRtangent_PolyPolyC(V, W) {
+            return tangent_PolyPolyC(V, W, Rtangent_PointPolyC, Rtangent_PointPolyC, above, above);
+        }
+        geom.RRtangent_PolyPolyC = RRtangent_PolyPolyC;
+
+        var BiTangent = (function () {
+            function BiTangent(t1, t2) {
+                this.t1 = t1;
+                this.t2 = t2;
+            }
+            return BiTangent;
+        })();
+        geom.BiTangent = BiTangent;
+
+        var BiTangents = (function () {
+            function BiTangents() {
+            }
+            return BiTangents;
+        })();
+        geom.BiTangents = BiTangents;
+
+        var TVGPoint = (function (_super) {
+            __extends(TVGPoint, _super);
+            function TVGPoint() {
+                _super.apply(this, arguments);
+            }
+            return TVGPoint;
+        })(Point);
+        geom.TVGPoint = TVGPoint;
+
+        var VisibilityVertex = (function () {
+            function VisibilityVertex(id, polyid, polyvertid, p) {
+                this.id = id;
+                this.polyid = polyid;
+                this.polyvertid = polyvertid;
+                this.p = p;
+                p.vv = this;
+            }
+            return VisibilityVertex;
+        })();
+        geom.VisibilityVertex = VisibilityVertex;
+
+        var VisibilityEdge = (function () {
+            function VisibilityEdge(source, target) {
+                this.source = source;
+                this.target = target;
+            }
+            VisibilityEdge.prototype.length = function () {
+                var dx = this.source.p.x - this.target.p.x;
+                var dy = this.source.p.y - this.target.p.y;
+                return Math.sqrt(dx * dx + dy * dy);
+            };
+            return VisibilityEdge;
+        })();
+        geom.VisibilityEdge = VisibilityEdge;
+
+        var TangentVisibilityGraph = (function () {
+            function TangentVisibilityGraph(P, g0) {
+                this.P = P;
+                this.V = [];
+                this.E = [];
+                if (!g0) {
+                    var n = P.length;
+                    for (var i = 0; i < n; i++) {
+                        var p = P[i];
+                        for (var j = 0; j < p.length; ++j) {
+                            var pj = p[j], vv = new VisibilityVertex(this.V.length, i, j, pj);
+                            this.V.push(vv);
+                            if (j > 0)
+                                this.E.push(new VisibilityEdge(p[j - 1].vv, vv));
+                        }
+                    }
+                    for (var i = 0; i < n - 1; i++) {
+                        var Pi = P[i];
+                        for (var j = i + 1; j < n; j++) {
+                            var Pj = P[j], t = geom.tangents(Pi, Pj);
+                            for (var q in t) {
+                                var c = t[q], source = Pi[c.t1], target = Pj[c.t2];
+                                this.addEdgeIfVisible(source, target, i, j);
+                            }
+                        }
+                    }
+                } else {
+                    this.V = g0.V.slice(0);
+                    this.E = g0.E.slice(0);
+                }
+            }
+            TangentVisibilityGraph.prototype.addEdgeIfVisible = function (u, v, i1, i2) {
+                if (!this.intersectsPolys(new LineSegment(u.x, u.y, v.x, v.y), i1, i2)) {
+                    this.E.push(new VisibilityEdge(u.vv, v.vv));
+                }
+            };
+            TangentVisibilityGraph.prototype.addPoint = function (p, i1) {
+                var n = this.P.length;
+                this.V.push(new VisibilityVertex(this.V.length, n, 0, p));
+                for (var i = 0; i < n; ++i) {
+                    if (i === i1)
+                        continue;
+                    var poly = this.P[i], t = tangent_PointPolyC(p, poly);
+                    this.addEdgeIfVisible(p, poly[t.ltan], i1, i);
+                    this.addEdgeIfVisible(p, poly[t.rtan], i1, i);
+                }
+                return p.vv;
+            };
+            TangentVisibilityGraph.prototype.intersectsPolys = function (l, i1, i2) {
+                for (var i = 0, n = this.P.length; i < n; ++i) {
+                    if (i != i1 && i != i2 && intersects(l, this.P[i]).length > 0) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+            return TangentVisibilityGraph;
+        })();
+        geom.TangentVisibilityGraph = TangentVisibilityGraph;
+
+        function intersects(l, P) {
+            var ints = [];
+            for (var i = 1, n = P.length; i < n; ++i) {
+                var int = cola.vpsc.Rectangle.lineIntersection(l.x1, l.y1, l.x2, l.y2, P[i - 1].x, P[i - 1].y, P[i].x, P[i].y);
+                if (int)
+                    ints.push(int);
+            }
+            return ints;
+        }
+
+        function tangents(V, W) {
+            var m = V.length - 1, n = W.length - 1;
+            var bt = new BiTangents();
+            for (var i = 0; i < m; ++i) {
+                for (var j = 0; j < n; ++j) {
+                    var v1 = V[i == 0 ? m - 1 : i - 1];
+                    var v2 = V[i];
+                    var v3 = V[i + 1];
+                    var w1 = W[j == 0 ? n - 1 : j - 1];
+                    var w2 = W[j];
+                    var w3 = W[j + 1];
+                    var v1v2w2 = isLeft(v1, v2, w2);
+                    var v2w1w2 = isLeft(v2, w1, w2);
+                    var v2w2w3 = isLeft(v2, w2, w3);
+                    var w1w2v2 = isLeft(w1, w2, v2);
+                    var w2v1v2 = isLeft(w2, v1, v2);
+                    var w2v2v3 = isLeft(w2, v2, v3);
+                    if (v1v2w2 >= 0 && v2w1w2 >= 0 && v2w2w3 < 0 && w1w2v2 >= 0 && w2v1v2 >= 0 && w2v2v3 < 0) {
+                        bt.ll = new BiTangent(i, j);
+                    } else if (v1v2w2 <= 0 && v2w1w2 <= 0 && v2w2w3 > 0 && w1w2v2 <= 0 && w2v1v2 <= 0 && w2v2v3 > 0) {
+                        bt.rr = new BiTangent(i, j);
+                    } else if (v1v2w2 <= 0 && v2w1w2 > 0 && v2w2w3 <= 0 && w1w2v2 >= 0 && w2v1v2 < 0 && w2v2v3 >= 0) {
+                        bt.rl = new BiTangent(i, j);
+                    } else if (v1v2w2 >= 0 && v2w1w2 < 0 && v2w2w3 >= 0 && w1w2v2 <= 0 && w2v1v2 > 0 && w2v2v3 <= 0) {
+                        bt.lr = new BiTangent(i, j);
+                    }
+                }
+            }
+            return bt;
+        }
+        geom.tangents = tangents;
+
+        function isPointInsidePoly(p, poly) {
+            for (var i = 1, n = poly.length; i < n; ++i)
+                if (below(poly[i - 1], poly[i], p))
+                    return false;
+            return true;
+        }
+
+        function isAnyPInQ(p, q) {
+            return !p.every(function (v) {
+                return !isPointInsidePoly(v, q);
+            });
+        }
+
+        function polysOverlap(p, q) {
+            if (isAnyPInQ(p, q))
+                return true;
+            if (isAnyPInQ(q, p))
+                return true;
+            for (var i = 1, n = p.length; i < n; ++i) {
+                var v = p[i], u = p[i - 1];
+                if (intersects(new LineSegment(u.x, u.y, v.x, v.y), q).length > 0)
+                    return true;
+            }
+            return false;
+        }
+        geom.polysOverlap = polysOverlap;
+    })(cola.geom || (cola.geom = {}));
+    var geom = cola.geom;
+})(cola || (cola = {}));
+var cola;
+(function (cola) {
+    (function (vpsc) {
+        var PositionStats = (function () {
+            function PositionStats(scale) {
+                this.scale = scale;
+                this.AB = 0;
+                this.AD = 0;
+                this.A2 = 0;
+            }
+            PositionStats.prototype.addVariable = function (v) {
+                var ai = this.scale / v.scale;
+                var bi = v.offset / v.scale;
+                var wi = v.weight;
+                this.AB += wi * ai * bi;
+                this.AD += wi * ai * v.desiredPosition;
+                this.A2 += wi * ai * ai;
+            };
+
+            PositionStats.prototype.getPosn = function () {
+                return (this.AD - this.AB) / this.A2;
+            };
+            return PositionStats;
+        })();
+        vpsc.PositionStats = PositionStats;
+
+        var Constraint = (function () {
+            function Constraint(left, right, gap, equality) {
+                if (typeof equality === "undefined") { equality = false; }
+                this.left = left;
+                this.right = right;
+                this.gap = gap;
+                this.equality = equality;
+                this.active = false;
+                this.unsatisfiable = false;
+                this.left = left;
+                this.right = right;
+                this.gap = gap;
+                this.equality = equality;
+            }
+            Constraint.prototype.slack = function () {
+                return this.unsatisfiable ? Number.MAX_VALUE : this.right.scale * this.right.position() - this.gap - this.left.scale * this.left.position();
+            };
+            return Constraint;
+        })();
+        vpsc.Constraint = Constraint;
+
+        var Variable = (function () {
+            function Variable(desiredPosition, weight, scale) {
+                if (typeof weight === "undefined") { weight = 1; }
+                if (typeof scale === "undefined") { scale = 1; }
+                this.desiredPosition = desiredPosition;
+                this.weight = weight;
+                this.scale = scale;
+                this.offset = 0;
+            }
+            Variable.prototype.dfdv = function () {
+                return 2.0 * this.weight * (this.position() - this.desiredPosition);
+            };
+
+            Variable.prototype.position = function () {
+                return (this.block.ps.scale * this.block.posn + this.offset) / this.scale;
+            };
+
+            Variable.prototype.visitNeighbours = function (prev, f) {
+                var ff = function (c, next) {
+                    return c.active && prev !== next && f(c, next);
+                };
+                this.cOut.forEach(function (c) {
+                    return ff(c, c.right);
+                });
+                this.cIn.forEach(function (c) {
+                    return ff(c, c.left);
+                });
+            };
+            return Variable;
+        })();
+        vpsc.Variable = Variable;
+
+        var Block = (function () {
+            function Block(v) {
+                this.vars = [];
+                v.offset = 0;
+                this.ps = new PositionStats(v.scale);
+                this.addVariable(v);
+            }
+            Block.prototype.addVariable = function (v) {
+                v.block = this;
+                this.vars.push(v);
+                this.ps.addVariable(v);
+                this.posn = this.ps.getPosn();
+            };
+
+            Block.prototype.updateWeightedPosition = function () {
+                this.ps.AB = this.ps.AD = this.ps.A2 = 0;
+                for (var i = 0, n = this.vars.length; i < n; ++i)
+                    this.ps.addVariable(this.vars[i]);
+                this.posn = this.ps.getPosn();
+            };
+
+            Block.prototype.compute_lm = function (v, u, postAction) {
+                var _this = this;
+                var dfdv = v.dfdv();
+                v.visitNeighbours(u, function (c, next) {
+                    var _dfdv = _this.compute_lm(next, v, postAction);
+                    if (next === c.right) {
+                        dfdv += _dfdv * c.left.scale;
+                        c.lm = _dfdv;
+                    } else {
+                        dfdv += _dfdv * c.right.scale;
+                        c.lm = -_dfdv;
+                    }
+                    postAction(c);
+                });
+                return dfdv / v.scale;
+            };
+
+            Block.prototype.populateSplitBlock = function (v, prev) {
+                var _this = this;
+                v.visitNeighbours(prev, function (c, next) {
+                    next.offset = v.offset + (next === c.right ? c.gap : -c.gap);
+                    _this.addVariable(next);
+                    _this.populateSplitBlock(next, v);
+                });
+            };
+
+            Block.prototype.traverse = function (visit, acc, v, prev) {
+                var _this = this;
+                if (typeof v === "undefined") { v = this.vars[0]; }
+                if (typeof prev === "undefined") { prev = null; }
+                v.visitNeighbours(prev, function (c, next) {
+                    acc.push(visit(c));
+                    _this.traverse(visit, acc, next, v);
+                });
+            };
+
+            Block.prototype.findMinLM = function () {
+                var m = null;
+                this.compute_lm(this.vars[0], null, function (c) {
+                    if (!c.equality && (m === null || c.lm < m.lm))
+                        m = c;
+                });
+                return m;
+            };
+
+            Block.prototype.findMinLMBetween = function (lv, rv) {
+                this.compute_lm(lv, null, function () {
+                });
+                var m = null;
+                this.findPath(lv, null, rv, function (c, next) {
+                    if (!c.equality && c.right === next && (m === null || c.lm < m.lm))
+                        m = c;
+                });
+                return m;
+            };
+
+            Block.prototype.findPath = function (v, prev, to, visit) {
+                var _this = this;
+                var endFound = false;
+                v.visitNeighbours(prev, function (c, next) {
+                    if (!endFound && (next === to || _this.findPath(next, v, to, visit))) {
+                        endFound = true;
+                        visit(c, next);
+                    }
+                });
+                return endFound;
+            };
+
+            Block.prototype.isActiveDirectedPathBetween = function (u, v) {
+                if (u === v)
+                    return true;
+                var i = u.cOut.length;
+                while (i--) {
+                    var c = u.cOut[i];
+                    if (c.active && this.isActiveDirectedPathBetween(c.right, v))
+                        return true;
+                }
+                return false;
+            };
+
+            Block.split = function (c) {
+                c.active = false;
+                return [Block.createSplitBlock(c.left), Block.createSplitBlock(c.right)];
+            };
+
+            Block.createSplitBlock = function (startVar) {
+                var b = new Block(startVar);
+                b.populateSplitBlock(startVar, null);
+                return b;
+            };
+
+            Block.prototype.splitBetween = function (vl, vr) {
+                var c = this.findMinLMBetween(vl, vr);
+                if (c !== null) {
+                    var bs = Block.split(c);
+                    return { constraint: c, lb: bs[0], rb: bs[1] };
+                }
+
+                return null;
+            };
+
+            Block.prototype.mergeAcross = function (b, c, dist) {
+                c.active = true;
+                for (var i = 0, n = b.vars.length; i < n; ++i) {
+                    var v = b.vars[i];
+                    v.offset += dist;
+                    this.addVariable(v);
+                }
+                this.posn = this.ps.getPosn();
+            };
+
+            Block.prototype.cost = function () {
+                var sum = 0, i = this.vars.length;
+                while (i--) {
+                    var v = this.vars[i], d = v.position() - v.desiredPosition;
+                    sum += d * d * v.weight;
+                }
+                return sum;
+            };
+            return Block;
+        })();
+        vpsc.Block = Block;
+
+        var Blocks = (function () {
+            function Blocks(vs) {
+                this.vs = vs;
+                var n = vs.length;
+                this.list = new Array(n);
+                while (n--) {
+                    var b = new Block(vs[n]);
+                    this.list[n] = b;
+                    b.blockInd = n;
+                }
+            }
+            Blocks.prototype.cost = function () {
+                var sum = 0, i = this.list.length;
+                while (i--)
+                    sum += this.list[i].cost();
+                return sum;
+            };
+
+            Blocks.prototype.insert = function (b) {
+                b.blockInd = this.list.length;
+                this.list.push(b);
+            };
+
+            Blocks.prototype.remove = function (b) {
+                var last = this.list.length - 1;
+                var swapBlock = this.list[last];
+                this.list.length = last;
+                if (b !== swapBlock) {
+                    this.list[b.blockInd] = swapBlock;
+                    swapBlock.blockInd = b.blockInd;
+                }
+            };
+
+            Blocks.prototype.merge = function (c) {
+                var l = c.left.block, r = c.right.block;
+
+                var dist = c.right.offset - c.left.offset - c.gap;
+                if (l.vars.length < r.vars.length) {
+                    r.mergeAcross(l, c, dist);
+                    this.remove(l);
+                } else {
+                    l.mergeAcross(r, c, -dist);
+                    this.remove(r);
+                }
+            };
+
+            Blocks.prototype.forEach = function (f) {
+                this.list.forEach(f);
+            };
+
+            Blocks.prototype.updateBlockPositions = function () {
+                this.list.forEach(function (b) {
+                    return b.updateWeightedPosition();
+                });
+            };
+
+            Blocks.prototype.split = function (inactive) {
+                var _this = this;
+                this.updateBlockPositions();
+                this.list.forEach(function (b) {
+                    var v = b.findMinLM();
+                    if (v !== null && v.lm < Solver.LAGRANGIAN_TOLERANCE) {
+                        b = v.left.block;
+                        Block.split(v).forEach(function (nb) {
+                            return _this.insert(nb);
+                        });
+                        _this.remove(b);
+                        inactive.push(v);
+                    }
+                });
+            };
+            return Blocks;
+        })();
+        vpsc.Blocks = Blocks;
+
+        var Solver = (function () {
+            function Solver(vs, cs) {
+                this.vs = vs;
+                this.cs = cs;
+                this.vs = vs;
+                vs.forEach(function (v) {
+                    v.cIn = [], v.cOut = [];
+                });
+                this.cs = cs;
+                cs.forEach(function (c) {
+                    c.left.cOut.push(c);
+                    c.right.cIn.push(c);
+                });
+                this.inactive = cs.map(function (c) {
+                    c.active = false;
+                    return c;
+                });
+                this.bs = null;
+            }
+            Solver.prototype.cost = function () {
+                return this.bs.cost();
+            };
+
+            Solver.prototype.setStartingPositions = function (ps) {
+                this.inactive = this.cs.map(function (c) {
+                    c.active = false;
+                    return c;
+                });
+                this.bs = new Blocks(this.vs);
+                this.bs.forEach(function (b, i) {
+                    return b.posn = ps[i];
+                });
+            };
+
+            Solver.prototype.setDesiredPositions = function (ps) {
+                this.vs.forEach(function (v, i) {
+                    return v.desiredPosition = ps[i];
+                });
+            };
+
+            Solver.prototype.mostViolated = function () {
+                var minSlack = Number.MAX_VALUE, v = null, l = this.inactive, n = l.length, deletePoint = n;
+                for (var i = 0; i < n; ++i) {
+                    var c = l[i];
+                    if (c.unsatisfiable)
+                        continue;
+                    var slack = c.slack();
+                    if (c.equality || slack < minSlack) {
+                        minSlack = slack;
+                        v = c;
+                        deletePoint = i;
+                        if (c.equality)
+                            break;
+                    }
+                }
+                if (deletePoint !== n && (minSlack < Solver.ZERO_UPPERBOUND && !v.active || v.equality)) {
+                    l[deletePoint] = l[n - 1];
+                    l.length = n - 1;
+                }
+                return v;
+            };
+
+            Solver.prototype.satisfy = function () {
+                if (this.bs == null) {
+                    this.bs = new Blocks(this.vs);
+                }
+
+                this.bs.split(this.inactive);
+                var v = null;
+                while ((v = this.mostViolated()) && (v.equality || v.slack() < Solver.ZERO_UPPERBOUND && !v.active)) {
+                    var lb = v.left.block, rb = v.right.block;
+
+                    if (lb !== rb) {
+                        this.bs.merge(v);
+                    } else {
+                        if (lb.isActiveDirectedPathBetween(v.right, v.left)) {
+                            v.unsatisfiable = true;
+                            continue;
+                        }
+
+                        var split = lb.splitBetween(v.left, v.right);
+                        if (split !== null) {
+                            this.bs.insert(split.lb);
+                            this.bs.insert(split.rb);
+                            this.bs.remove(lb);
+                            this.inactive.push(split.constraint);
+                        } else {
+                            v.unsatisfiable = true;
+                            continue;
+                        }
+                        if (v.slack() >= 0) {
+                            this.inactive.push(v);
+                        } else {
+                            this.bs.merge(v);
+                        }
+                    }
+                }
+            };
+
+            Solver.prototype.solve = function () {
+                this.satisfy();
+                var lastcost = Number.MAX_VALUE, cost = this.bs.cost();
+                while (Math.abs(lastcost - cost) > 0.0001) {
+                    this.satisfy();
+                    lastcost = cost;
+                    cost = this.bs.cost();
+                }
+                return cost;
+            };
+            Solver.LAGRANGIAN_TOLERANCE = -1e-4;
+            Solver.ZERO_UPPERBOUND = -1e-10;
+            return Solver;
+        })();
+        vpsc.Solver = Solver;
+    })(cola.vpsc || (cola.vpsc = {}));
+    var vpsc = cola.vpsc;
+})(cola || (cola = {}));
+var cola;
+(function (cola) {
+    (function (vpsc) {
+        function computeGroupBounds(g) {
+            g.bounds = typeof g.leaves !== "undefined" ? g.leaves.reduce(function (r, c) {
+                return c.bounds.union(r);
+            }, Rectangle.empty()) : Rectangle.empty();
+            if (typeof g.groups !== "undefined")
+                g.bounds = g.groups.reduce(function (r, c) {
+                    return computeGroupBounds(c).union(r);
+                }, g.bounds);
+            g.bounds = g.bounds.inflate(g.padding);
+            return g.bounds;
+        }
+        vpsc.computeGroupBounds = computeGroupBounds;
+
+        var Rectangle = (function () {
+            function Rectangle(x, X, y, Y) {
+                this.x = x;
+                this.X = X;
+                this.y = y;
+                this.Y = Y;
+            }
+            Rectangle.empty = function () {
+                return new Rectangle(Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY);
+            };
+
+            Rectangle.prototype.cx = function () {
+                return (this.x + this.X) / 2;
+            };
+
+            Rectangle.prototype.cy = function () {
+                return (this.y + this.Y) / 2;
+            };
+
+            Rectangle.prototype.overlapX = function (r) {
+                var ux = this.cx(), vx = r.cx();
+                if (ux <= vx && r.x < this.X)
+                    return this.X - r.x;
+                if (vx <= ux && this.x < r.X)
+                    return r.X - this.x;
+                return 0;
+            };
+
+            Rectangle.prototype.overlapY = function (r) {
+                var uy = this.cy(), vy = r.cy();
+                if (uy <= vy && r.y < this.Y)
+                    return this.Y - r.y;
+                if (vy <= uy && this.y < r.Y)
+                    return r.Y - this.y;
+                return 0;
+            };
+
+            Rectangle.prototype.setXCentre = function (cx) {
+                var dx = cx - this.cx();
+                this.x += dx;
+                this.X += dx;
+            };
+
+            Rectangle.prototype.setYCentre = function (cy) {
+                var dy = cy - this.cy();
+                this.y += dy;
+                this.Y += dy;
+            };
+
+            Rectangle.prototype.width = function () {
+                return this.X - this.x;
+            };
+
+            Rectangle.prototype.height = function () {
+                return this.Y - this.y;
+            };
+
+            Rectangle.prototype.union = function (r) {
+                return new Rectangle(Math.min(this.x, r.x), Math.max(this.X, r.X), Math.min(this.y, r.y), Math.max(this.Y, r.Y));
+            };
+
+            Rectangle.prototype.lineIntersections = function (x1, y1, x2, y2) {
+                var sides = [
+                    [this.x, this.y, this.X, this.y],
+                    [this.X, this.y, this.X, this.Y],
+                    [this.X, this.Y, this.x, this.Y],
+                    [this.x, this.Y, this.x, this.y]];
+                var intersections = [];
+                for (var i = 0; i < 4; ++i) {
+                    var r = Rectangle.lineIntersection(x1, y1, x2, y2, sides[i][0], sides[i][1], sides[i][2], sides[i][3]);
+                    if (r !== null)
+                        intersections.push({ x: r.x, y: r.y });
+                }
+                return intersections;
+            };
+
+            Rectangle.prototype.rayIntersection = function (x2, y2) {
+                var ints = this.lineIntersections(this.cx(), this.cy(), x2, y2);
+                return ints.length > 0 ? ints[0] : null;
+            };
+
+            Rectangle.prototype.vertices = function () {
+                return [
+                    { x: this.x, y: this.y },
+                    { x: this.X, y: this.y },
+                    { x: this.X, y: this.Y },
+                    { x: this.x, y: this.Y },
+                    { x: this.x, y: this.y }];
+            };
+
+            Rectangle.lineIntersection = function (x1, y1, x2, y2, x3, y3, x4, y4) {
+                var dx12 = x2 - x1, dx34 = x4 - x3, dy12 = y2 - y1, dy34 = y4 - y3, denominator = dy34 * dx12 - dx34 * dy12;
+                if (denominator == 0)
+                    return null;
+                var dx31 = x1 - x3, dy31 = y1 - y3, numa = dx34 * dy31 - dy34 * dx31, a = numa / denominator, numb = dx12 * dy31 - dy12 * dx31, b = numb / denominator;
+                if (a >= 0 && a <= 1 && b >= 0 && b <= 1) {
+                    return {
+                        x: x1 + a * dx12,
+                        y: y1 + a * dy12
+                    };
+                }
+                return null;
+            };
+
+            Rectangle.prototype.inflate = function (pad) {
+                return new Rectangle(this.x - pad, this.X + pad, this.y - pad, this.Y + pad);
+            };
+            return Rectangle;
+        })();
+        vpsc.Rectangle = Rectangle;
+
+        function makeEdgeBetween(link, source, target, ah) {
+            var si = source.rayIntersection(target.cx(), target.cy());
+            if (!si)
+                si = { x: source.cx(), y: source.cy() };
+            var ti = target.rayIntersection(source.cx(), source.cy());
+            if (!ti)
+                ti = { x: target.cx(), y: target.cy() };
+            var dx = ti.x - si.x, dy = ti.y - si.y, l = Math.sqrt(dx * dx + dy * dy), al = l - ah;
+            link.sourceIntersection = si;
+            link.targetIntersection = ti;
+            link.arrowStart = { x: si.x + al * dx / l, y: si.y + al * dy / l };
+        }
+        vpsc.makeEdgeBetween = makeEdgeBetween;
+
+        function makeEdgeTo(s, target, ah) {
+            var ti = target.rayIntersection(s.x, s.y);
+            if (!ti)
+                ti = { x: target.cx(), y: target.cy() };
+            var dx = ti.x - s.x, dy = ti.y - s.y, l = Math.sqrt(dx * dx + dy * dy);
+            return { x: ti.x - ah * dx / l, y: ti.y - ah * dy / l };
+        }
+        vpsc.makeEdgeTo = makeEdgeTo;
+
+        var Node = (function () {
+            function Node(v, r, pos) {
+                this.v = v;
+                this.r = r;
+                this.pos = pos;
+                this.prev = makeRBTree();
+                this.next = makeRBTree();
+            }
+            return Node;
+        })();
+
+        var Event = (function () {
+            function Event(isOpen, v, pos) {
+                this.isOpen = isOpen;
+                this.v = v;
+                this.pos = pos;
+            }
+            return Event;
+        })();
+
+        function compareEvents(a, b) {
+            if (a.pos > b.pos) {
+                return 1;
+            }
+            if (a.pos < b.pos) {
+                return -1;
+            }
+            if (a.isOpen) {
+                return -1;
+            }
+            return 0;
+        }
+
+        function makeRBTree() {
+            return new RBTree(function (a, b) {
+                return a.pos - b.pos;
+            });
+        }
+
+        var xRect = {
+            getCentre: function (r) {
+                return r.cx();
+            },
+            getOpen: function (r) {
+                return r.y;
+            },
+            getClose: function (r) {
+                return r.Y;
+            },
+            getSize: function (r) {
+                return r.width();
+            },
+            makeRect: function (open, close, center, size) {
+                return new Rectangle(center - size / 2, center + size / 2, open, close);
+            },
+            findNeighbours: findXNeighbours
+        };
+
+        var yRect = {
+            getCentre: function (r) {
+                return r.cy();
+            },
+            getOpen: function (r) {
+                return r.x;
+            },
+            getClose: function (r) {
+                return r.X;
+            },
+            getSize: function (r) {
+                return r.height();
+            },
+            makeRect: function (open, close, center, size) {
+                return new Rectangle(open, close, center - size / 2, center + size / 2);
+            },
+            findNeighbours: findYNeighbours
+        };
+
+        function generateGroupConstraints(root, f, minSep, isContained) {
+            if (typeof isContained === "undefined") { isContained = false; }
+            var padding = root.padding, gn = typeof root.groups !== 'undefined' ? root.groups.length : 0, ln = typeof root.leaves !== 'undefined' ? root.leaves.length : 0, childConstraints = !gn ? [] : root.groups.reduce(function (ccs, g) {
+                return ccs.concat(generateGroupConstraints(g, f, minSep, true));
+            }, []), n = (isContained ? 2 : 0) + ln + gn, vs = new Array(n), rs = new Array(n), i = 0, add = function (r, v) {
+                rs[i] = r;
+                vs[i++] = v;
+            };
+            if (isContained) {
+                var b = root.bounds, c = f.getCentre(b), s = f.getSize(b) / 2, open = f.getOpen(b), close = f.getClose(b), min = c - s + padding / 2, max = c + s - padding / 2;
+                root.minVar.desiredPosition = min;
+                add(f.makeRect(open, close, min, padding), root.minVar);
+                root.maxVar.desiredPosition = max;
+                add(f.makeRect(open, close, max, padding), root.maxVar);
+            }
+            if (ln)
+                root.leaves.forEach(function (l) {
+                    return add(l.bounds, l.variable);
+                });
+            if (gn)
+                root.groups.forEach(function (g) {
+                    var b = g.bounds;
+                    add(f.makeRect(f.getOpen(b), f.getClose(b), f.getCentre(b), f.getSize(b)), g.minVar);
+                });
+            var cs = generateConstraints(rs, vs, f, minSep);
+            if (gn) {
+                vs.forEach(function (v) {
+                    v.cOut = [], v.cIn = [];
+                });
+                cs.forEach(function (c) {
+                    c.left.cOut.push(c), c.right.cIn.push(c);
+                });
+                root.groups.forEach(function (g) {
+                    var gapAdjustment = (g.padding - f.getSize(g.bounds)) / 2;
+                    g.minVar.cIn.forEach(function (c) {
+                        return c.gap += gapAdjustment;
+                    });
+                    g.minVar.cOut.forEach(function (c) {
+                        c.left = g.maxVar;
+                        c.gap += gapAdjustment;
+                    });
+                });
+            }
+            return childConstraints.concat(cs);
+        }
+
+        function generateConstraints(rs, vars, rect, minSep) {
+            var i, n = rs.length;
+            var N = 2 * n;
+            console.assert(vars.length >= n);
+            var events = new Array(N);
+            for (i = 0; i < n; ++i) {
+                var r = rs[i];
+                var v = new Node(vars[i], r, rect.getCentre(r));
+                events[i] = new Event(true, v, rect.getOpen(r));
+                events[i + n] = new Event(false, v, rect.getClose(r));
+            }
+            events.sort(compareEvents);
+            var cs = new Array();
+            var scanline = makeRBTree();
+            for (i = 0; i < N; ++i) {
+                var e = events[i];
+                var v = e.v;
+                if (e.isOpen) {
+                    scanline.insert(v);
+                    rect.findNeighbours(v, scanline);
+                } else {
+                    scanline.remove(v);
+                    var makeConstraint = function (l, r) {
+                        var sep = (rect.getSize(l.r) + rect.getSize(r.r)) / 2 + minSep;
+                        cs.push(new cola.vpsc.Constraint(l.v, r.v, sep));
+                    };
+                    var visitNeighbours = function (forward, reverse, mkcon) {
+                        var u, it = v[forward].iterator();
+                        while ((u = it[forward]()) !== null) {
+                            mkcon(u, v);
+                            u[reverse].remove(v);
+                        }
+                    };
+                    visitNeighbours("prev", "next", function (u, v) {
+                        return makeConstraint(u, v);
+                    });
+                    visitNeighbours("next", "prev", function (u, v) {
+                        return makeConstraint(v, u);
+                    });
+                }
+            }
+            console.assert(scanline.size === 0);
+            return cs;
+        }
+
+        function findXNeighbours(v, scanline) {
+            var f = function (forward, reverse) {
+                var it = scanline.findIter(v);
+                var u;
+                while ((u = it[forward]()) !== null) {
+                    var uovervX = u.r.overlapX(v.r);
+                    if (uovervX <= 0 || uovervX <= u.r.overlapY(v.r)) {
+                        v[forward].insert(u);
+                        u[reverse].insert(v);
+                    }
+                    if (uovervX <= 0) {
+                        break;
+                    }
+                }
+            };
+            f("next", "prev");
+            f("prev", "next");
+        }
+
+        function findYNeighbours(v, scanline) {
+            var f = function (forward, reverse) {
+                var u = scanline.findIter(v)[forward]();
+                if (u !== null && u.r.overlapX(v.r) > 0) {
+                    v[forward].insert(u);
+                    u[reverse].insert(v);
+                }
+            };
+            f("next", "prev");
+            f("prev", "next");
+        }
+
+        function generateXConstraints(rs, vars) {
+            return generateConstraints(rs, vars, xRect, 1e-6);
+        }
+        vpsc.generateXConstraints = generateXConstraints;
+
+        function generateYConstraints(rs, vars) {
+            return generateConstraints(rs, vars, yRect, 1e-6);
+        }
+        vpsc.generateYConstraints = generateYConstraints;
+
+        function generateXGroupConstraints(root) {
+            return generateGroupConstraints(root, xRect, 1e-6);
+        }
+        vpsc.generateXGroupConstraints = generateXGroupConstraints;
+
+        function generateYGroupConstraints(root) {
+            return generateGroupConstraints(root, yRect, 1e-6);
+        }
+        vpsc.generateYGroupConstraints = generateYGroupConstraints;
+
+        function removeOverlaps(rs) {
+            var vs = rs.map(function (r) {
+                return new cola.vpsc.Variable(r.cx());
+            });
+            var cs = cola.vpsc.generateXConstraints(rs, vs);
+            var solver = new cola.vpsc.Solver(vs, cs);
+            solver.solve();
+            vs.forEach(function (v, i) {
+                return rs[i].setXCentre(v.position());
+            });
+            vs = rs.map(function (r) {
+                return new cola.vpsc.Variable(r.cy());
+            });
+            cs = cola.vpsc.generateYConstraints(rs, vs);
+            solver = new cola.vpsc.Solver(vs, cs);
+            solver.solve();
+            vs.forEach(function (v, i) {
+                return rs[i].setYCentre(v.position());
+            });
+        }
+        vpsc.removeOverlaps = removeOverlaps;
+
+        var IndexedVariable = (function (_super) {
+            __extends(IndexedVariable, _super);
+            function IndexedVariable(index, w) {
+                _super.call(this, 0, w);
+                this.index = index;
+            }
+            return IndexedVariable;
+        })(cola.vpsc.Variable);
+
+        var Projection = (function () {
+            function Projection(nodes, groups, rootGroup, constraints, avoidOverlaps) {
+                if (typeof rootGroup === "undefined") { rootGroup = null; }
+                if (typeof constraints === "undefined") { constraints = null; }
+                if (typeof avoidOverlaps === "undefined") { avoidOverlaps = false; }
+                var _this = this;
+                this.nodes = nodes;
+                this.groups = groups;
+                this.rootGroup = rootGroup;
+                this.avoidOverlaps = avoidOverlaps;
+                this.variables = nodes.map(function (v, i) {
+                    return v.variable = new IndexedVariable(i, 1);
+                });
+
+                if (constraints)
+                    this.createConstraints(constraints);
+
+                if (avoidOverlaps && rootGroup && typeof rootGroup.groups !== 'undefined') {
+                    nodes.forEach(function (v) {
+                        if (!v.width || !v.height) {
+                            v.bounds = new cola.vpsc.Rectangle(v.x, v.x, v.y, v.y);
+                            return;
+                        }
+                        var w2 = v.width / 2, h2 = v.height / 2;
+                        v.bounds = new cola.vpsc.Rectangle(v.x - w2, v.x + w2, v.y - h2, v.y + h2);
+                    });
+                    computeGroupBounds(rootGroup);
+                    var i = nodes.length;
+                    groups.forEach(function (g) {
+                        _this.variables[i] = g.minVar = new IndexedVariable(i++, 0.01);
+                        _this.variables[i] = g.maxVar = new IndexedVariable(i++, 0.01);
+                    });
+                }
+            }
+            Projection.prototype.createSeparation = function (c) {
+                return new cola.vpsc.Constraint(this.nodes[c.left].variable, this.nodes[c.right].variable, c.gap, typeof c.equality !== "undefined" ? c.equality : false);
+            };
+
+            Projection.prototype.makeFeasible = function (c) {
+                var _this = this;
+                if (!this.avoidOverlaps)
+                    return;
+                var axis = 'x', dim = 'width';
+                if (c.axis === 'x')
+                    axis = 'y', dim = 'height';
+                var vs = c.offsets.map(function (o) {
+                    return _this.nodes[o.node];
+                }).sort(function (a, b) {
+                    return a[axis] - b[axis];
+                });
+                var p = null;
+                vs.forEach(function (v) {
+                    if (p)
+                        v[axis] = p[axis] + p[dim] + 1;
+                    p = v;
+                });
+            };
+
+            Projection.prototype.createAlignment = function (c) {
+                var _this = this;
+                var u = this.nodes[c.offsets[0].node].variable;
+                this.makeFeasible(c);
+                var cs = c.axis === 'x' ? this.xConstraints : this.yConstraints;
+                c.offsets.slice(1).forEach(function (o) {
+                    var v = _this.nodes[o.node].variable;
+                    cs.push(new cola.vpsc.Constraint(u, v, o.offset, true));
+                });
+            };
+
+            Projection.prototype.createConstraints = function (constraints) {
+                var _this = this;
+                var isSep = function (c) {
+                    return typeof c.type === 'undefined' || c.type === 'separation';
+                };
+                this.xConstraints = constraints.filter(function (c) {
+                    return c.axis === "x" && isSep(c);
+                }).map(function (c) {
+                    return _this.createSeparation(c);
+                });
+                this.yConstraints = constraints.filter(function (c) {
+                    return c.axis === "y" && isSep(c);
+                }).map(function (c) {
+                    return _this.createSeparation(c);
+                });
+                constraints.filter(function (c) {
+                    return c.type === 'alignment';
+                }).forEach(function (c) {
+                    return _this.createAlignment(c);
+                });
+            };
+
+            Projection.prototype.setupVariablesAndBounds = function (x0, y0, desired, getDesired) {
+                this.nodes.forEach(function (v, i) {
+                    if (v.fixed) {
+                        v.variable.weight = 1000;
+                        desired[i] = getDesired(v);
+                    } else {
+                        v.variable.weight = 1;
+                    }
+                    var w = (v.width || 0) / 2, h = (v.height || 0) / 2;
+                    var ix = x0[i], iy = y0[i];
+                    v.bounds = new Rectangle(ix - w, ix + w, iy - h, iy + h);
+                });
+            };
+
+            Projection.prototype.xProject = function (x0, y0, x) {
+                if (!this.rootGroup && !(this.avoidOverlaps || this.xConstraints))
+                    return;
+                this.project(x0, y0, x0, x, function (v) {
+                    return v.px;
+                }, this.xConstraints, generateXGroupConstraints, function (v) {
+                    return v.bounds.setXCentre(x[v.variable.index] = v.variable.position());
+                }, function (g) {
+                    var xmin = x[g.minVar.index] = g.minVar.position();
+                    var xmax = x[g.maxVar.index] = g.maxVar.position();
+                    var p2 = g.padding / 2;
+                    g.bounds.x = xmin - p2;
+                    g.bounds.X = xmax + p2;
+                });
+            };
+
+            Projection.prototype.yProject = function (x0, y0, y) {
+                if (!this.rootGroup && !this.yConstraints)
+                    return;
+                this.project(x0, y0, y0, y, function (v) {
+                    return v.py;
+                }, this.yConstraints, generateYGroupConstraints, function (v) {
+                    return v.bounds.setYCentre(y[v.variable.index] = v.variable.position());
+                }, function (g) {
+                    var ymin = y[g.minVar.index] = g.minVar.position();
+                    var ymax = y[g.maxVar.index] = g.maxVar.position();
+                    var p2 = g.padding / 2;
+                    g.bounds.y = ymin - p2;
+                    ;
+                    g.bounds.Y = ymax + p2;
+                });
+            };
+
+            Projection.prototype.projectFunctions = function () {
+                var _this = this;
+                return [
+                    function (x0, y0, x) {
+                        return _this.xProject(x0, y0, x);
+                    },
+                    function (x0, y0, y) {
+                        return _this.yProject(x0, y0, y);
+                    }
+                ];
+            };
+
+            Projection.prototype.project = function (x0, y0, start, desired, getDesired, cs, generateConstraints, updateNodeBounds, updateGroupBounds) {
+                this.setupVariablesAndBounds(x0, y0, desired, getDesired);
+                if (this.rootGroup && this.avoidOverlaps) {
+                    computeGroupBounds(this.rootGroup);
+                    cs = cs.concat(generateConstraints(this.rootGroup));
+                }
+                this.solve(this.variables, cs, start, desired);
+                this.nodes.forEach(updateNodeBounds);
+                if (this.rootGroup && this.avoidOverlaps) {
+                    this.groups.forEach(updateGroupBounds);
+                }
+            };
+
+            Projection.prototype.solve = function (vs, cs, starting, desired) {
+                var solver = new cola.vpsc.Solver(vs, cs);
+                solver.setStartingPositions(starting);
+                solver.setDesiredPositions(desired);
+                solver.solve();
+            };
+            return Projection;
+        })();
+        vpsc.Projection = Projection;
+    })(cola.vpsc || (cola.vpsc = {}));
+    var vpsc = cola.vpsc;
+})(cola || (cola = {}));
+var GridRouter = (function () {
+    function GridRouter(graph) {
+        var _this = this;
+        this.groupPadding = 5;
+        this.leaves = null;
+        this.nodes = graph.nodes;
+        this.leaves = this.nodes.filter(this.isLeaf);
+        this.leaves.forEach(function (v) {
+            return v.rect = new cola.vpsc.Rectangle(v.bounds.x, v.bounds.X, v.bounds.y, v.bounds.Y);
+        });
+        this.groups = this.nodes.filter(function (g) {
+            return _this.isGroup(g);
+        });
+        this.cols = this.getGridDim('x');
+        this.rows = this.getGridDim('y');
+
+        this.groups.forEach(function (v) {
+            return v.children.forEach(function (c) {
+                return _this.nodes[c].parent = v;
+            });
+        });
+
+        this.root = { children: [] };
+        this.nodes.forEach(function (v) {
+            if (typeof v.parent === 'undefined') {
+                v.parent = _this.root;
+                _this.root.children.push(v.id);
+            }
+
+            v.ports = [];
+        });
+
+        this.backToFront = this.nodes.slice(0);
+        this.backToFront.sort(function (x, y) {
+            return _this.getDepth(x) - _this.getDepth(y);
+        });
+
+        var frontToBackGroups = this.backToFront.slice(0).reverse().filter(function (g) {
+            return _this.isGroup(g);
+        });
+        frontToBackGroups.forEach(function (v) {
+            var r = cola.vpsc.Rectangle.empty();
+            v.children.forEach(function (c) {
+                return r = r.union(_this.nodes[c].rect);
+            });
+            v.rect = r.inflate(_this.groupPadding);
+        });
+
+        var colMids = this.midPoints(this.cols.map(function (r) {
+            return r.x;
+        }));
+        var rowMids = this.midPoints(this.rows.map(function (r) {
+            return r.y;
+        }));
+
+        var rowx = colMids[0], rowX = colMids[colMids.length - 1];
+        var coly = rowMids[0], colY = rowMids[rowMids.length - 1];
+
+        var hlines = this.rows.map(function (r) {
+            return { x1: rowx, x2: rowX, y1: r.y, y2: r.y };
+        }).concat(rowMids.map(function (m) {
+            return { x1: rowx, x2: rowX, y1: m, y2: m };
+        }));
+
+        var vlines = this.cols.map(function (c) {
+            return { x1: c.x, x2: c.x, y1: coly, y2: colY };
+        }).concat(colMids.map(function (m) {
+            return { x1: m, x2: m, y1: coly, y2: colY };
+        }));
+
+        var lines = hlines.concat(vlines);
+
+        lines.forEach(function (l) {
+            return l.verts = [];
+        });
+
+        this.verts = [];
+        this.edges = [];
+
+        hlines.forEach(function (h) {
+            return vlines.forEach(function (v) {
+                var p = { id: _this.verts.length, x: v.x1, y: h.y1 };
+                h.verts.push(p);
+                v.verts.push(p);
+                _this.verts.push(p);
+
+                var i = _this.backToFront.length;
+                while (i-- > 0) {
+                    var node = _this.backToFront[i], r = node.rect;
+                    var dx = Math.abs(p.x - r.cx()), dy = Math.abs(p.y - r.cy());
+                    if (dx < r.width() / 2 && dy < r.height() / 2) {
+                        p.node = node;
+                        break;
+                    }
+                }
+            });
+        });
+
+        lines.forEach(function (l) {
+            _this.nodes.forEach(function (v) {
+                v.rect.lineIntersections(l.x1, l.y1, l.x2, l.y2).forEach(function (p) {
+                    p.line = l;
+                    p.node = v;
+                    p.id = _this.verts.length;
+                    _this.verts.push(p);
+                    l.verts.push(p);
+                    v.ports.push(p);
+                });
+            });
+
+            var isHoriz = Math.abs(l.y1 - l.y2) < 0.1;
+            var delta = function (a, b) {
+                return isHoriz ? b.x - a.x : b.y - a.y;
+            };
+            l.verts.sort(delta);
+            for (var i = 1; i < l.verts.length; i++) {
+                var u = l.verts[i - 1], v = l.verts[i];
+                if (u.node && u.node === v.node && _this.isLeaf(u.node))
+                    continue;
+                _this.edges.push({ source: u.id, target: v.id, length: Math.abs(delta(u, v)) });
+            }
+        });
+    }
+    GridRouter.prototype.isLeaf = function (v) {
+        return typeof v.children === 'undefined';
+    };
+    GridRouter.prototype.isGroup = function (v) {
+        return !this.isLeaf(v);
+    };
+    GridRouter.prototype.avg = function (a) {
+        return a.reduce(function (x, y) {
+            return x + y;
+        }) / a.length;
+    };
+    GridRouter.prototype.getGridDim = function (axis) {
+        var columns = [];
+        var ls = this.leaves.slice(0, this.leaves.length);
+        while (ls.length > 0) {
+            var r = ls[0].rect;
+            var col = ls.filter(function (v) {
+                return v.rect['overlap' + axis.toUpperCase()](r);
+            });
+            columns.push(col);
+            col.forEach(function (v) {
+                return ls.splice(ls.indexOf(v), 1);
+            });
+            col[axis] = this.avg(col.map(function (v) {
+                return v.rect['c' + axis]();
+            }));
+        }
+        columns.sort(function (x, y) {
+            return x[axis] - y[axis];
+        });
+        return columns;
+    };
+
+    GridRouter.prototype.getDepth = function (v) {
+        var depth = 0;
+        while (v.parent !== this.root) {
+            depth++;
+            v = v.parent;
+        }
+        return depth;
+    };
+
+    GridRouter.prototype.midPoints = function (a) {
+        var gap = a[1] - a[0];
+        var mids = [a[0] - gap / 2];
+        for (var i = 1; i < a.length; i++) {
+            mids.push((a[i] + a[i - 1]) / 2);
+        }
+        mids.push(a[a.length - 1] + gap / 2);
+        return mids;
+    };
+
+    GridRouter.prototype.findLineage = function (v) {
+        var lineage = [v];
+        do {
+            v = v.parent;
+            lineage.push(v);
+        } while(v !== this.root);
+        return lineage.reverse();
+    };
+
+    GridRouter.prototype.findAncestorPathBetween = function (a, b) {
+        var aa = this.findLineage(a), ba = this.findLineage(b), i = 0;
+        while (aa[i] === ba[i])
+            i++;
+
+        return { commonAncestor: aa[i - 1], lineages: aa.slice(i).concat(ba.slice(i)) };
+    };
+
+    GridRouter.prototype.siblingObstacles = function (a, b) {
+        var _this = this;
+        var path = this.findAncestorPathBetween(a, b);
+        var lineageLookup = {};
+        path.lineages.forEach(function (v) {
+            return lineageLookup[v.id] = {};
+        });
+        var obstacles = path.commonAncestor.children.filter(function (v) {
+            return !(v in lineageLookup);
+        });
+
+        path.lineages.filter(function (v) {
+            return v.parent !== path.commonAncestor;
+        }).forEach(function (v) {
+            return obstacles = obstacles.concat(v.parent.children.filter(function (c) {
+                return c !== v.id;
+            }));
+        });
+
+        return obstacles.map(function (v) {
+            return _this.nodes[v];
+        });
+    };
+    return GridRouter;
+})();
+var cola;
+(function (cola) {
+    function unionCount(a, b) {
+        var u = {};
+        for (var i in a)
+            u[i] = {};
+        for (var i in b)
+            u[i] = {};
+        return Object.keys(u).length;
+    }
+
+    function intersectionCount(a, b) {
+        var n = 0;
+        for (var i in a)
+            if (typeof b[i] !== 'undefined')
+                ++n;
+        return n;
+    }
+
+    function getNeighbours(links, la) {
+        var neighbours = {};
+        var addNeighbours = function (u, v) {
+            if (typeof neighbours[u] === 'undefined')
+                neighbours[u] = {};
+            neighbours[u][v] = {};
+        };
+        links.forEach(function (e) {
+            var u = la.getSourceIndex(e), v = la.getTargetIndex(e);
+            addNeighbours(u, v);
+            addNeighbours(v, u);
+        });
+        return neighbours;
+    }
+
+    function computeLinkLengths(links, w, f, la) {
+        var neighbours = getNeighbours(links, la);
+        links.forEach(function (l) {
+            var a = neighbours[la.getSourceIndex(l)];
+            var b = neighbours[la.getTargetIndex(l)];
+            la.setLength(l, 1 + w * f(a, b));
+        });
+    }
+
+    function symmetricDiffLinkLengths(links, la, w) {
+        if (typeof w === "undefined") { w = 1; }
+        computeLinkLengths(links, w, function (a, b) {
+            return Math.sqrt(unionCount(a, b) - intersectionCount(a, b));
+        }, la);
+    }
+    cola.symmetricDiffLinkLengths = symmetricDiffLinkLengths;
+
+    function jaccardLinkLengths(links, la, w) {
+        if (typeof w === "undefined") { w = 1; }
+        computeLinkLengths(links, w, function (a, b) {
+            return Math.min(Object.keys(a).length, Object.keys(b).length) < 1.1 ? 0 : intersectionCount(a, b) / unionCount(a, b);
+        }, la);
+    }
+    cola.jaccardLinkLengths = jaccardLinkLengths;
+
+    function generateDirectedEdgeConstraints(n, links, axis, la) {
+        var components = stronglyConnectedComponents(n, links, la);
+        var nodes = {};
+        components.filter(function (c) {
+            return c.length > 1;
+        }).forEach(function (c) {
+            return c.forEach(function (v) {
+                return nodes[v] = c;
+            });
+        });
+        var constraints = [];
+        links.forEach(function (l) {
+            var ui = la.getSourceIndex(l), vi = la.getTargetIndex(l), u = nodes[ui], v = nodes[vi];
+            if (!u || !v || u.component !== v.component) {
+                constraints.push({
+                    axis: axis,
+                    left: ui,
+                    right: vi,
+                    gap: la.getMinSeparation(l)
+                });
+            }
+        });
+        return constraints;
+    }
+    cola.generateDirectedEdgeConstraints = generateDirectedEdgeConstraints;
+
+    function stronglyConnectedComponents(numVertices, edges, la) {
+        var adjList = new Array(numVertices);
+        var index = new Array(numVertices);
+        var lowValue = new Array(numVertices);
+        var active = new Array(numVertices);
+
+        for (var i = 0; i < numVertices; ++i) {
+            adjList[i] = [];
+            index[i] = -1;
+            lowValue[i] = 0;
+            active[i] = false;
+        }
+
+        for (var i = 0; i < edges.length; ++i) {
+            adjList[la.getSourceIndex(edges[i])].push(la.getTargetIndex(edges[i]));
+        }
+
+        var count = 0;
+        var S = [];
+        var components = [];
+
+        function strongConnect(v) {
+            index[v] = count;
+            lowValue[v] = count;
+            active[v] = true;
+            count += 1;
+            S.push(v);
+            var e = adjList[v];
+            for (var i = 0; i < e.length; ++i) {
+                var u = e[i];
+                if (index[u] < 0) {
+                    strongConnect(u);
+                    lowValue[v] = Math.min(lowValue[v], lowValue[u]) | 0;
+                } else if (active[u]) {
+                    lowValue[v] = Math.min(lowValue[v], lowValue[u]);
+                }
+            }
+            if (lowValue[v] === index[v]) {
+                var component = [];
+                for (var i = S.length - 1; i >= 0; --i) {
+                    var w = S[i];
+                    active[w] = false;
+                    component.push(w);
+                    if (w === v) {
+                        S.length = i;
+                        break;
+                    }
+                }
+                components.push(component);
+            }
+        }
+
+        for (var i = 0; i < numVertices; ++i) {
+            if (index[i] < 0) {
+                strongConnect(i);
+            }
+        }
+
+        return components;
+    }
+})(cola || (cola = {}));
+var cola;
+(function (cola) {
+    (function (powergraph) {
+        var PowerEdge = (function () {
+            function PowerEdge(source, target, type) {
+                this.source = source;
+                this.target = target;
+                this.type = type;
+            }
+            return PowerEdge;
+        })();
+        powergraph.PowerEdge = PowerEdge;
+
+        var Configuration = (function () {
+            function Configuration(n, edges, linkAccessor) {
+                var _this = this;
+                this.linkAccessor = linkAccessor;
+                this.modules = new Array(n);
+                this.roots = new ModuleSet();
+                for (var i = 0; i < n; ++i) {
+                    this.roots.add(this.modules[i] = new Module(i));
+                }
+                this.R = edges.length;
+                edges.forEach(function (e) {
+                    var s = _this.modules[linkAccessor.getSourceIndex(e)], t = _this.modules[linkAccessor.getTargetIndex(e)], type = linkAccessor.getType(e);
+                    s.outgoing.add(type, t);
+                    t.incoming.add(type, s);
+                });
+            }
+            Configuration.prototype.merge = function (a, b) {
+                var inInt = a.incoming.intersection(b.incoming), outInt = a.outgoing.intersection(b.outgoing);
+                var children = new ModuleSet();
+                children.add(a);
+                children.add(b);
+                var m = new Module(this.modules.length, outInt, inInt, children);
+                this.modules.push(m);
+                var update = function (s, i, o) {
+                    s.forAll(function (ms, linktype) {
+                        ms.forAll(function (n) {
+                            var nls = n[i];
+                            nls.add(linktype, m);
+                            nls.remove(linktype, a);
+                            nls.remove(linktype, b);
+                            a[o].remove(linktype, n);
+                            b[o].remove(linktype, n);
+                        });
+                    });
+                };
+                update(outInt, "incoming", "outgoing");
+                update(inInt, "outgoing", "incoming");
+                this.R -= inInt.count() + outInt.count();
+                this.roots.remove(a);
+                this.roots.remove(b);
+                this.roots.add(m);
+                return m;
+            };
+
+            Configuration.prototype.rootMerges = function () {
+                var rs = this.roots.modules();
+                var n = rs.length;
+                var merges = new Array(n * (n - 1));
+                var ctr = 0;
+                for (var i = 0, i_ = n - 1; i < i_; ++i) {
+                    for (var j = i + 1; j < n; ++j) {
+                        var a = rs[i], b = rs[j];
+                        merges[ctr++] = { nEdges: this.nEdges(a, b), a: a, b: b };
+                    }
+                }
+                return merges;
+            };
+
+            Configuration.prototype.greedyMerge = function () {
+                var ms = this.rootMerges().sort(function (a, b) {
+                    return a.nEdges - b.nEdges;
+                });
+                var m = ms[0];
+                if (m.nEdges >= this.R)
+                    return false;
+                this.merge(m.a, m.b);
+                return true;
+            };
+
+            Configuration.prototype.nEdges = function (a, b) {
+                var inInt = a.incoming.intersection(b.incoming), outInt = a.outgoing.intersection(b.outgoing);
+                return this.R - inInt.count() - outInt.count();
+            };
+
+            Configuration.prototype.getGroupHierarchy = function (retargetedEdges) {
+                var _this = this;
+                var groups = [];
+                var root = {};
+                toGroups(this.roots, root, groups);
+                var es = this.allEdges();
+                es.forEach(function (e) {
+                    var a = _this.modules[e.source];
+                    var b = _this.modules[e.target];
+                    retargetedEdges.push(new PowerEdge(typeof a.gid === "undefined" ? e.source : groups[a.gid], typeof b.gid === "undefined" ? e.target : groups[b.gid], e.type));
+                });
+                return groups;
+            };
+
+            Configuration.prototype.allEdges = function () {
+                var es = [];
+                Configuration.getEdges(this.roots, es);
+                return es;
+            };
+
+            Configuration.getEdges = function (modules, es) {
+                modules.forAll(function (m) {
+                    m.getEdges(es);
+                    Configuration.getEdges(m.children, es);
+                });
+            };
+            return Configuration;
+        })();
+        powergraph.Configuration = Configuration;
+
+        function toGroups(modules, group, groups) {
+            modules.forAll(function (m) {
+                if (m.isLeaf()) {
+                    if (!group.leaves)
+                        group.leaves = [];
+                    group.leaves.push(m.id);
+                } else {
+                    var g = group;
+                    m.gid = groups.length;
+                    if (!m.isIsland()) {
+                        g = { id: m.gid };
+                        if (!group.groups)
+                            group.groups = [];
+                        group.groups.push(m.gid);
+                        groups.push(g);
+                    }
+                    toGroups(m.children, g, groups);
+                }
+            });
+        }
+
+        var Module = (function () {
+            function Module(id, outgoing, incoming, children) {
+                if (typeof outgoing === "undefined") { outgoing = new LinkSets(); }
+                if (typeof incoming === "undefined") { incoming = new LinkSets(); }
+                if (typeof children === "undefined") { children = new ModuleSet(); }
+                this.id = id;
+                this.outgoing = outgoing;
+                this.incoming = incoming;
+                this.children = children;
+            }
+            Module.prototype.getEdges = function (es) {
+                var _this = this;
+                this.outgoing.forAll(function (ms, edgetype) {
+                    ms.forAll(function (target) {
+                        es.push(new PowerEdge(_this.id, target.id, edgetype));
+                    });
+                });
+            };
+
+            Module.prototype.isLeaf = function () {
+                return this.children.count() === 0;
+            };
+
+            Module.prototype.isIsland = function () {
+                return this.outgoing.count() === 0 && this.incoming.count() === 0;
+            };
+            return Module;
+        })();
+        powergraph.Module = Module;
+
+        function intersection(m, n) {
+            var i = {};
+            for (var v in m)
+                if (v in n)
+                    i[v] = m[v];
+            return i;
+        }
+
+        var ModuleSet = (function () {
+            function ModuleSet() {
+                this.table = {};
+            }
+            ModuleSet.prototype.count = function () {
+                return Object.keys(this.table).length;
+            };
+            ModuleSet.prototype.intersection = function (other) {
+                var result = new ModuleSet();
+                result.table = intersection(this.table, other.table);
+                return result;
+            };
+            ModuleSet.prototype.intersectionCount = function (other) {
+                return this.intersection(other).count();
+            };
+            ModuleSet.prototype.contains = function (id) {
+                return id in this.table;
+            };
+            ModuleSet.prototype.add = function (m) {
+                this.table[m.id] = m;
+            };
+            ModuleSet.prototype.remove = function (m) {
+                delete this.table[m.id];
+            };
+            ModuleSet.prototype.forAll = function (f) {
+                for (var mid in this.table) {
+                    f(this.table[mid]);
+                }
+            };
+            ModuleSet.prototype.modules = function () {
+                var vs = [];
+                this.forAll(function (m) {
+                    return vs.push(m);
+                });
+                return vs;
+            };
+            return ModuleSet;
+        })();
+        powergraph.ModuleSet = ModuleSet;
+
+        var LinkSets = (function () {
+            function LinkSets() {
+                this.sets = {};
+                this.n = 0;
+            }
+            LinkSets.prototype.count = function () {
+                return this.n;
+            };
+            LinkSets.prototype.contains = function (id) {
+                var result = false;
+                this.forAllModules(function (m) {
+                    if (!result && m.id == id) {
+                        result = true;
+                    }
+                });
+                return result;
+            };
+            LinkSets.prototype.add = function (linktype, m) {
+                var s = linktype in this.sets ? this.sets[linktype] : this.sets[linktype] = new ModuleSet();
+                s.add(m);
+                ++this.n;
+            };
+            LinkSets.prototype.remove = function (linktype, m) {
+                var ms = this.sets[linktype];
+                ms.remove(m);
+                if (ms.count() === 0) {
+                    delete this.sets[linktype];
+                }
+                --this.n;
+            };
+            LinkSets.prototype.forAll = function (f) {
+                for (var linktype in this.sets) {
+                    f(this.sets[linktype], linktype);
+                }
+            };
+            LinkSets.prototype.forAllModules = function (f) {
+                this.forAll(function (ms, lt) {
+                    return ms.forAll(f);
+                });
+            };
+            LinkSets.prototype.intersection = function (other) {
+                var result = new LinkSets();
+                this.forAll(function (ms, lt) {
+                    if (lt in other.sets) {
+                        var i = ms.intersection(other.sets[lt]), n = i.count();
+                        if (n > 0) {
+                            result.sets[lt] = i;
+                            result.n += n;
+                        }
+                    }
+                });
+                return result;
+            };
+            return LinkSets;
+        })();
+        powergraph.LinkSets = LinkSets;
+
+        function intersectionCount(m, n) {
+            return Object.keys(intersection(m, n)).length;
+        }
+
+        function getGroups(nodes, links, la) {
+            var n = nodes.length, c = new powergraph.Configuration(n, links, la);
+            while (c.greedyMerge())
+                ;
+            var powerEdges = [];
+            var g = c.getGroupHierarchy(powerEdges);
+            powerEdges.forEach(function (e) {
+                var f = function (end) {
+                    var g = e[end];
+                    if (typeof g == "number")
+                        e[end] = nodes[g];
+                };
+                f("source");
+                f("target");
+            });
+            return { groups: g, powerEdges: powerEdges };
+        }
+        powergraph.getGroups = getGroups;
+    })(cola.powergraph || (cola.powergraph = {}));
+    var powergraph = cola.powergraph;
+})(cola || (cola = {}));
+var PairingHeap = (function () {
+    function PairingHeap(elem) {
+        this.elem = elem;
+        this.subheaps = [];
+    }
+    PairingHeap.prototype.toString = function (selector) {
+        var str = "", needComma = false;
+        for (var i = 0; i < this.subheaps.length; ++i) {
+            var subheap = this.subheaps[i];
+            if (!subheap.elem) {
+                needComma = false;
+                continue;
+            }
+            if (needComma) {
+                str = str + ",";
+            }
+            str = str + subheap.toString(selector);
+            needComma = true;
+        }
+        if (str !== "") {
+            str = "(" + str + ")";
+        }
+        return (this.elem ? selector(this.elem) : "") + str;
+    };
+
+    PairingHeap.prototype.forEach = function (f) {
+        if (!this.empty()) {
+            f(this.elem, this);
+            this.subheaps.forEach(function (s) {
+                return s.forEach(f);
+            });
+        }
+    };
+
+    PairingHeap.prototype.count = function () {
+        return this.empty() ? 0 : 1 + this.subheaps.reduce(function (n, h) {
+            return n + h.count();
+        }, 0);
+    };
+
+    PairingHeap.prototype.min = function () {
+        return this.elem;
+    };
+
+    PairingHeap.prototype.empty = function () {
+        return this.elem == null;
+    };
+
+    PairingHeap.prototype.contains = function (h) {
+        if (this === h)
+            return true;
+        for (var i = 0; i < this.subheaps.length; i++) {
+            if (this.subheaps[i].contains(h))
+                return true;
+        }
+        return false;
+    };
+
+    PairingHeap.prototype.isHeap = function (lessThan) {
+        var _this = this;
+        return this.subheaps.every(function (h) {
+            return lessThan(_this.elem, h.elem) && h.isHeap(lessThan);
+        });
+    };
+
+    PairingHeap.prototype.insert = function (obj, lessThan) {
+        return this.merge(new PairingHeap(obj), lessThan);
+    };
+
+    PairingHeap.prototype.merge = function (heap2, lessThan) {
+        if (this.empty())
+            return heap2;
+        else if (heap2.empty())
+            return this;
+        else if (lessThan(this.elem, heap2.elem)) {
+            this.subheaps.push(heap2);
+            return this;
+        } else {
+            heap2.subheaps.push(this);
+            return heap2;
+        }
+    };
+
+    PairingHeap.prototype.removeMin = function (lessThan) {
+        if (this.empty())
+            return null;
+        else
+            return this.mergePairs(lessThan);
+    };
+
+    PairingHeap.prototype.mergePairs = function (lessThan) {
+        if (this.subheaps.length == 0)
+            return new PairingHeap(null);
+        else if (this.subheaps.length == 1) {
+            return this.subheaps[0];
+        } else {
+            var firstPair = this.subheaps.pop().merge(this.subheaps.pop(), lessThan);
+            var remaining = this.mergePairs(lessThan);
+            return firstPair.merge(remaining, lessThan);
+        }
+    };
+    PairingHeap.prototype.decreaseKey = function (subheap, newValue, setHeapNode, lessThan) {
+        var newHeap = subheap.removeMin(lessThan);
+
+        subheap.elem = newHeap.elem;
+        subheap.subheaps = newHeap.subheaps;
+        if (setHeapNode !== null && newHeap.elem !== null) {
+            setHeapNode(subheap.elem, subheap);
+        }
+        var pairingNode = new PairingHeap(newValue);
+        if (setHeapNode !== null) {
+            setHeapNode(newValue, pairingNode);
+        }
+        return this.merge(pairingNode, lessThan);
+    };
+    return PairingHeap;
+})();
+
+var PriorityQueue = (function () {
+    function PriorityQueue(lessThan) {
+        this.lessThan = lessThan;
+    }
+    PriorityQueue.prototype.top = function () {
+        if (this.empty()) {
+            return null;
+        }
+        return this.root.elem;
+    };
+
+    PriorityQueue.prototype.push = function () {
+        var args = [];
+        for (var _i = 0; _i < (arguments.length - 0); _i++) {
+            args[_i] = arguments[_i + 0];
+        }
+        var pairingNode;
+        for (var i = 0, arg; arg = args[i]; ++i) {
+            pairingNode = new PairingHeap(arg);
+            this.root = this.empty() ? pairingNode : this.root.merge(pairingNode, this.lessThan);
+        }
+        return pairingNode;
+    };
+
+    PriorityQueue.prototype.empty = function () {
+        return !this.root || !this.root.elem;
+    };
+
+    PriorityQueue.prototype.isHeap = function () {
+        return this.root.isHeap(this.lessThan);
+    };
+
+    PriorityQueue.prototype.forEach = function (f) {
+        this.root.forEach(f);
+    };
+
+    PriorityQueue.prototype.pop = function () {
+        if (this.empty()) {
+            return null;
+        }
+        var obj = this.root.min();
+        this.root = this.root.removeMin(this.lessThan);
+        return obj;
+    };
+
+    PriorityQueue.prototype.reduceKey = function (heapNode, newKey, setHeapNode) {
+        if (typeof setHeapNode === "undefined") { setHeapNode = null; }
+        this.root = this.root.decreaseKey(heapNode, newKey, setHeapNode, this.lessThan);
+    };
+    PriorityQueue.prototype.toString = function (selector) {
+        return this.root.toString(selector);
+    };
+
+    PriorityQueue.prototype.count = function () {
+        return this.root.count();
+    };
+    return PriorityQueue;
+})();
+var cola;
+(function (cola) {
+    (function (shortestpaths) {
+        var Neighbour = (function () {
+            function Neighbour(id, distance) {
+                this.id = id;
+                this.distance = distance;
+            }
+            return Neighbour;
+        })();
+
+        var Node = (function () {
+            function Node(id) {
+                this.id = id;
+                this.neighbours = [];
+            }
+            return Node;
+        })();
+
+        var Calculator = (function () {
+            function Calculator(n, es, getSourceIndex, getTargetIndex, getLength) {
+                this.n = n;
+                this.es = es;
+                this.neighbours = new Array(this.n);
+                var i = this.n;
+                while (i--)
+                    this.neighbours[i] = new Node(i);
+
+                i = this.es.length;
+                while (i--) {
+                    var e = this.es[i];
+                    var u = getSourceIndex(e), v = getTargetIndex(e);
+                    var d = getLength(e);
+                    this.neighbours[u].neighbours.push(new Neighbour(v, d));
+                    this.neighbours[v].neighbours.push(new Neighbour(u, d));
+                }
+            }
+            Calculator.prototype.DistanceMatrix = function () {
+                var D = new Array(this.n);
+                for (var i = 0; i < this.n; ++i) {
+                    D[i] = this.dijkstraNeighbours(i);
+                }
+                return D;
+            };
+
+            Calculator.prototype.DistancesFromNode = function (start) {
+                return this.dijkstraNeighbours(start);
+            };
+
+            Calculator.prototype.PathFromNodeToNode = function (start, end) {
+                return this.dijkstraNeighbours(start, end);
+            };
+
+            Calculator.prototype.dijkstraNeighbours = function (start, dest) {
+                if (typeof dest === "undefined") { dest = -1; }
+                var q = new PriorityQueue(function (a, b) {
+                    return a.d <= b.d;
+                }), i = this.neighbours.length, d = new Array(i);
+                while (i--) {
+                    var node = this.neighbours[i];
+                    node.d = i === start ? 0 : Number.POSITIVE_INFINITY;
+                    node.q = q.push(node);
+                }
+                while (!q.empty()) {
+                    var u = q.pop();
+                    d[u.id] = u.d;
+                    if (u.id === dest) {
+                        var path = [];
+                        var v = u;
+                        while (typeof v.prev !== 'undefined') {
+                            path.push(v.prev.id);
+                            v = v.prev;
+                        }
+                        return path;
+                    }
+                    i = u.neighbours.length;
+                    while (i--) {
+                        var neighbour = u.neighbours[i];
+                        var v = this.neighbours[neighbour.id];
+                        var t = u.d + neighbour.distance;
+                        if (u.d !== Number.MAX_VALUE && v.d > t) {
+                            v.d = t;
+                            v.prev = u;
+                            q.reduceKey(v.q, v, function (e, q) {
+                                return e.q = q;
+                            });
+                        }
+                    }
+                }
+                return d;
+            };
+            return Calculator;
+        })();
+        shortestpaths.Calculator = Calculator;
+    })(cola.shortestpaths || (cola.shortestpaths = {}));
+    var shortestpaths = cola.shortestpaths;
+})(cola || (cola = {}));
+
+/**
+ * @module cola
+ */
+var cola;
+(function (cola) {
+
+    /**
+     * @class d3adaptor
+     */
+    cola.d3adaptor = function () {
+        var event = d3.dispatch("start", "tick", "end");
+
+        var adaptor = cola.adaptor({
+            trigger: function (e) {
+                event[e.type](e); // via d3 dispatcher, e.g. event.start(e);
+            },
+
+            on: function(type, listener){
+                return event.on(type, listener);
+            },
+
+            kick: function (tick) {
+                d3.timer(tick);
+            },
+
+            // use `node.call(adaptor.drag)` to make nodes draggable
+            drag: function () {
+                var drag = d3.behavior.drag()
+                    .origin(function(d){ return d; })
+                    .on("dragstart.d3adaptor", colaDragstart)
+                    .on("drag.d3adaptor", function (d) {
+                        d.px = d3.event.x, d.py = d3.event.y;
+                        adaptor.resume(); // restart annealing
+                    })
+                    .on("dragend.d3adaptor", colaDragend);
+
+                if (!arguments.length) return drag;
+
+                this//.on("mouseover.adaptor", colaMouseover)
+                    //.on("mouseout.adaptor", colaMouseout)
+                    .call(drag);
+            }
+        });
+        
+        return adaptor;
+    };
+
+    /**
+     * @class adaptor
+     */
+    cola.adaptor = function (options) {   
+        var adaptor = {},
+            trigger = options.trigger, // a function that is notified of events like "tick"
+            kick = options.kick, // a function that kicks off the simulation tick loop
+            size = [1, 1],
+            linkDistance = 20,
+            linkType = null,
+            avoidOverlaps = false,
+            handleDisconnected = true,
+            drag,
+            alpha,
+            lastStress,
+            running = false,
+            nodes = [],
+            groups = [],
+            variables = [],
+            rootGroup = null,
+            links = [],
+            constraints = [],
+            distanceMatrix = null,
+            descent = null,
+            directedLinkConstraints = null,
+            threshold = 0.01,
+            defaultNodeSize = 10,
+            visibilityGraph = null;
+
+        adaptor.on = options.on; // a function for binding to events on the adapter
+        adaptor.drag = options.drag; // a function to allow for dragging of nodes
+
+        // give external access to drag-related helper functions
+        adaptor.dragstart = colaDragstart;
+        adaptor.dragend = colaDragend;
+        adaptor.mouseover = colaMouseover;
+        adaptor.mouseout = colaMouseout;
+
+        adaptor.tick = function () {
+            if (alpha < threshold) {
+                trigger({ type: "end", alpha: alpha = 0 });
+                delete lastStress;
+                running = false;
+                return true;
+            }
+
+            var n = nodes.length,
+                m = links.length,
+                o;
+
+            descent.locks.clear();
+            for (i = 0; i < n; ++i) {
+                o = nodes[i];
+                if (o.fixed) {
+                    if (typeof o.px === 'undefined' || typeof o.py === 'undefined') {
+                        o.px = o.x;
+                        o.py = o.y;
+                    }
+                    var p = [o.px, o.py];
+                    descent.locks.add(i, p);
+                }
+            }
+
+            var s1 = descent.rungeKutta();
+            //var s1 = descent.reduceStress();
+            if (s1 === 0) {
+                alpha = 0;
+            } else if (typeof lastStress !== 'undefined') {
+                alpha = Math.abs(Math.abs(lastStress / s1) - 1);
+            }
+            lastStress = s1;
+
+            for (i = 0; i < n; ++i) {
+                o = nodes[i];
+                if (o.fixed) {
+                    o.x = o.px;
+                    o.y = o.py;
+                } else {
+                    o.x = descent.x[0][i];
+                    o.y = descent.x[1][i];
+                }
+            }
+
+            trigger({ type: "tick", alpha: alpha });
+        };
+
+        /**
+         * the list of nodes.
+         * If nodes has not been set, but links has, then we instantiate a nodes list here, of the correct size,
+         * before returning it.
+         * @property nodes {Array}
+         * @default empty list
+         */
+        adaptor.nodes = function (v) {
+            if (!arguments.length) {
+                if (nodes.length === 0 && links.length > 0) {
+                    var n = 0;
+                    links.forEach(function (l) {
+                        n = Math.max(n, l.source, l.target);
+                    });
+                    nodes = new Array(++n);
+                    for (var i = 0; i < n; ++i) {
+                        nodes[i] = {};
+                    }
+                }
+                return nodes;
+            }
+            nodes = v;
+            return adaptor;
+        };
+
+        /**
+         * a list of hierarchical groups defined over nodes
+         * @property groups {Array}
+         * @default empty list
+         */
+        adaptor.groups = function (x) {
+            if (!arguments.length) return groups;
+            groups = x;
+            rootGroup = {};
+            groups.forEach(function (g) {
+                if (typeof g.padding === "undefined")
+                    g.padding = 1;
+                if (typeof g.leaves !== "undefined")
+                    g.leaves.forEach(function (v, i) { (g.leaves[i] = nodes[v]).parent = g });
+                if (typeof g.groups !== "undefined")
+                    g.groups.forEach(function (gi, i) { (g.groups[i] = groups[gi]).parent = g });
+            });
+            rootGroup.leaves = nodes.filter(function (v) { return typeof v.parent === 'undefined'; });
+            rootGroup.groups = groups.filter(function (g) { return typeof g.parent === 'undefined'; });
+            return adaptor;
+        };
+
+        adaptor.powerGraphGroups = function (f) {
+            var g = cola.powergraph.getGroups(nodes, links, linkAccessor);
+            this.groups(g.groups);
+            f(g);
+            return adaptor;
+        }
+
+        /**
+         * if true, the layout will not permit overlaps of the node bounding boxes (defined by the width and height properties on nodes)
+         * @property avoidOverlaps
+         * @type bool
+         * @default false
+         */
+        adaptor.avoidOverlaps = function (v) {
+            if (!arguments.length) return avoidOverlaps;
+            avoidOverlaps = v;
+            return adaptor;
+        }
+
+        /**
+         * if true, the layout will not permit overlaps of the node bounding boxes (defined by the width and height properties on nodes)
+         * @property avoidOverlaps
+         * @type bool
+         * @default false
+         */
+        adaptor.handleDisconnected = function (v) {
+            if (!arguments.length) return handleDisconnected;
+            handleDisconnected = v;
+            return adaptor;
+        }
+
+
+        /**
+         * causes constraints to be generated such that directed graphs are laid out either from left-to-right or top-to-bottom.
+         * a separation constraint is generated in the selected axis for each edge that is not involved in a cycle (part of a strongly connected component)
+         * @param axis {string} 'x' for left-to-right, 'y' for top-to-bottom
+         * @param minSeparation {number|link=>number} either a number specifying a minimum spacing required across all links or a function to return the minimum spacing for each link
+         */
+        adaptor.flowLayout = function (axis, minSeparation) {
+            if (!arguments.length) axis = 'y';
+            directedLinkConstraints = {
+                axis: axis,
+                getMinSeparation: typeof minSeparation === 'number' ?  function () { return minSeparation } : minSeparation
+            };
+            return adaptor;
+        }
+
+        /**
+         * links defined as source, target pairs over nodes
+         * @property links {array}
+         * @default empty list
+         */
+        adaptor.links = function (x) {
+            if (!arguments.length) return links;
+            links = x;
+            return adaptor;
+        };
+
+        /**
+         * list of constraints of various types
+         * @property constraints
+         * @type {array} 
+         * @default empty list
+         */
+        adaptor.constraints = function (c) {
+            if (!arguments.length) return constraints;
+            constraints = c;
+            return adaptor;
+        }
+
+        /**
+         * Matrix of ideal distances between all pairs of nodes.
+         * If unspecified, the ideal distances for pairs of nodes will be based on the shortest path distance between them.
+         * @property distanceMatrix
+         * @type {Array of Array of Number}
+         * @default null
+         */
+        adaptor.distanceMatrix = function (d) {
+            if (!arguments.length) return distanceMatrix;
+            distanceMatrix = d;
+            return adaptor;
+        }
+
+        /**
+         * Size of the layout canvas dimensions [x,y]. Currently only used to determine the midpoint which is taken as the starting position
+         * for nodes with no preassigned x and y.
+         * @property size
+         * @type {Array of Number}
+         */
+        adaptor.size = function (x) {
+            if (!arguments.length) return size;
+            size = x;
+            return adaptor;
+        };
+
+        /**
+         * Default size (assume nodes are square so both width and height) to use in packing if node width/height are not specified.
+         * @property defaultNodeSize
+         * @type {Number}
+         */
+        adaptor.defaultNodeSize = function (x) {
+            if (!arguments.length) return defaultNodeSize;
+            defaultNodeSize = x;
+            return adaptor;
+        };
+
+        adaptor.linkDistance = function (x) {
+            if (!arguments.length) 
+                return typeof linkDistance === "function" ? linkDistance() : linkDistance;
+            linkDistance = typeof x === "function" ? x : +x;
+            return adaptor;
+        };
+
+        adaptor.linkType = function (f) {
+            linkType = f;
+            return adaptor;
+        }
+
+        adaptor.convergenceThreshold = function (x) {
+            if (!arguments.length) return threshold;
+            threshold = typeof x === "function" ? x : +x;
+            return adaptor;
+        };
+
+        adaptor.alpha = function (x) {
+            if (!arguments.length) return alpha;
+
+            x = +x;
+            if (alpha) { // if we're already running
+                if (x > 0) alpha = x; // we might keep it hot
+                else alpha = 0; // or, next tick will dispatch "end"
+            } else if (x > 0) { // otherwise, fire it up!
+                if (!running) {
+                    running = true;
+                    trigger({ type: "start", alpha: alpha = x });
+                    kick( adaptor.tick );
+                }
+            }
+
+            return adaptor;
+        };
+
+        function getLinkLength(link) {
+            return typeof linkDistance === "function" ? +linkDistance.call(null, link) : linkDistance;
+        }
+
+        function setLinkLength(link, length) {
+            link.length = length;
+        }
+
+        function getLinkType(link) {
+            return typeof linkType === "function" ? linkType(link) : 0;
+        }
+
+        var linkAccessor = { getSourceIndex: getSourceIndex, getTargetIndex: getTargetIndex, setLength: setLinkLength, getType: getLinkType };
+
+        adaptor.symmetricDiffLinkLengths = function (idealLength, w) {
+            cola.symmetricDiffLinkLengths(links, linkAccessor, w);
+            this.linkDistance(function (l) { return idealLength * l.length });
+            return adaptor;
+        }
+
+        adaptor.jaccardLinkLengths = function (idealLength, w) {
+            cola.jaccardLinkLengths(links, linkAccessor, w);
+            this.linkDistance(function (l) { return idealLength * l.length });
+            return adaptor;
+        }
+
+        /**
+         * start the layout process
+         * @method start
+         * @param {number} [initialUnconstrainedIterations=0] unconstrained initial layout iterations 
+         * @param {number} [initialUserConstraintIterations=0] initial layout iterations with user-specified constraints
+         * @param {number} [initialAllConstraintsIterations=0] initial layout iterations with all constraints including non-overlap
+         */
+        adaptor.start = function () {
+            var i,
+                j,
+                n = this.nodes().length,
+                N = n + 2 * groups.length,
+                m = links.length,
+                w = size[0],
+                h = size[1];
+
+            var x = new Array(N), y = new Array(N);
+            variables = new Array(N);
+
+            var makeVariable = function (i, w) {
+                var v = variables[i] = new cola.vpsc.Variable(0, w);
+                v.index = i;
+                return v;
+            }
+
+            var G = null;
+
+            var ao = this.avoidOverlaps();
+
+            nodes.forEach(function (v, i) {
+                v.index = i;
+                if (typeof v.x === 'undefined') {
+                    v.x = w / 2, v.y = h / 2;
+                }
+                x[i] = v.x, y[i] = v.y;
+            });
+
+            var distances;
+            if (distanceMatrix) {
+                // use the user specified distanceMatrix
+                distances = distanceMatrix;
+            } else {
+                // construct an n X n distance matrix based on shortest paths through graph (with respect to edge.length).
+                distances = (new cola.shortestpaths.Calculator(N, links, getSourceIndex, getTargetIndex, getLinkLength)).DistanceMatrix();
+
+                // G is a square matrix with G[i][j] = 1 iff there exists an edge between node i and node j
+                // otherwise 2. (
+                G = cola.Descent.createSquareMatrix(N, function () { return 2 });
+                links.forEach(function (e) {
+                    var u = getSourceIndex(e), v = getTargetIndex(e);
+                    G[u][v] = G[v][u] = 1;
+                });
+            }
+
+            var D = cola.Descent.createSquareMatrix(N, function (i, j) {
+                return distances[i][j];
+            });
+
+            if (rootGroup && typeof rootGroup.groups !== 'undefined') {
+                var i = n;
+                groups.forEach(function(g) {
+                    G[i][i + 1] = G[i + 1][i] = 1e-6;
+                    D[i][i + 1] = D[i + 1][i] = 0.1;
+                    x[i] = 0, y[i++] = 0;
+                    x[i] = 0, y[i++] = 0;
+                });
+            } else rootGroup = { leaves: nodes, groups: [] };
+
+            var curConstraints = constraints || [];
+            if (directedLinkConstraints) {
+                linkAccessor.getMinSeparation = directedLinkConstraints.getMinSeparation;
+                curConstraints = curConstraints.concat(cola.generateDirectedEdgeConstraints(n, links, directedLinkConstraints.axis, linkAccessor));
+            }
+            
+            var initialUnconstrainedIterations = arguments.length > 0 ? arguments[0] : 0;
+            var initialUserConstraintIterations = arguments.length > 1 ? arguments[1] : 0;
+            var initialAllConstraintsIterations = arguments.length > 2 ? arguments[2] : 0;
+            this.avoidOverlaps(false);
+            descent = new cola.Descent([x, y], D);
+
+            descent.locks.clear();
+            for (i = 0; i < n; ++i) {
+                o = nodes[i];
+                if (o.fixed) {
+                    o.px = o.x;
+                    o.py = o.y;
+                    var p = [o.x, o.y];
+                    descent.locks.add(i, p);
+                }
+            }
+            descent.threshold = threshold;
+
+            // apply initialIterations without user constraints or nonoverlap constraints
+            descent.run(initialUnconstrainedIterations);
+
+            // apply initialIterations with user constraints but no noverlap constraints
+            if (curConstraints.length > 0) descent.project = new cola.vpsc.Projection(nodes, groups, rootGroup, curConstraints).projectFunctions();
+            descent.run(initialUserConstraintIterations);
+
+            // subsequent iterations will apply all constraints
+            this.avoidOverlaps(ao);
+            if (ao) descent.project = new cola.vpsc.Projection(nodes, groups, rootGroup, curConstraints, true).projectFunctions();
+
+            // allow not immediately connected nodes to relax apart (p-stress)
+            descent.G = G;
+            descent.run(initialAllConstraintsIterations);
+
+            links.forEach(function (l) {
+                if (typeof l.source == "number") l.source = nodes[l.source];
+                if (typeof l.target == "number") l.target = nodes[l.target];
+            });
+            nodes.forEach(function (v, i) {
+                v.x = x[i], v.y = y[i];
+            });
+
+            // recalculate nodes position for disconnected graphs
+            if (!distanceMatrix && handleDisconnected) {
+                cola.applyPacking(cola.separateGraphs(nodes, links), w, h, defaultNodeSize);
+
+                nodes.forEach(function (v, i) {
+                    descent.x[0][i] = v.x, descent.x[1][i] = v.y;
+                });
+            }
+            
+            return adaptor.resume();
+        };
+
+        adaptor.resume = function () {
+            return adaptor.alpha(.1);
+        };
+
+        adaptor.stop = function () {
+            return adaptor.alpha(0);
+        };
+
+        adaptor.prepareEdgeRouting = function (nodeMargin) {
+            visibilityGraph = new cola.geom.TangentVisibilityGraph(
+                    nodes.map(function (v) {
+                        return v.bounds.inflate(-nodeMargin).vertices();
+                    }));
+        }
+
+        adaptor.routeEdge = function(d, draw) {
+            var lineData = [];
+            if (d.source.id === 10 && d.target.id === 11) {
+                debugger;
+            }
+            var vg2 = new cola.geom.TangentVisibilityGraph(visibilityGraph.P, { V: visibilityGraph.V, E: visibilityGraph.E }),
+                port1 = { x: d.source.x, y: d.source.y },
+                port2 = { x: d.target.x, y: d.target.y },
+                start = vg2.addPoint(port1, d.source.id),
+                end = vg2.addPoint(port2, d.target.id);
+            vg2.addEdgeIfVisible(port1, port2, d.source.id, d.target.id);
+            if (typeof draw !== 'undefined') {
+                draw(vg2);
+            }
+            var sourceInd = function(e) { return e.source.id }, targetInd = function(e) { return e.target.id }, length = function(e) { return e.length() }, 
+                spCalc = new cola.shortestpaths.Calculator(vg2.V.length, vg2.E, sourceInd, targetInd, length),
+                shortestPath = spCalc.PathFromNodeToNode(start.id, end.id);
+            if (shortestPath.length === 1 || shortestPath.length === vg2.V.length) {
+                cola.vpsc.makeEdgeBetween(d, d.source.innerBounds, d.target.innerBounds, 5);
+                lineData = [{ x: d.sourceIntersection.x, y: d.sourceIntersection.y }, { x: d.arrowStart.x, y: d.arrowStart.y }];
+            } else {
+                var n = shortestPath.length - 2,
+                    p = vg2.V[shortestPath[n]].p,
+                    q = vg2.V[shortestPath[0]].p,
+                    lineData = [d.source.innerBounds.rayIntersection(p.x, p.y)];
+                for (var i = n; i >= 0; --i) 
+                    lineData.push(vg2.V[shortestPath[i]].p);
+                lineData.push(cola.vpsc.makeEdgeTo(q, d.target.innerBounds, 5));
+            }
+            lineData.forEach(function (v, i) {
+                if (i > 0) {
+                    var u = lineData[i - 1];
+                    nodes.forEach(function (node) {
+                        if (node.id === getSourceIndex(d) || node.id === getTargetIndex(d)) return;
+                        var ints = node.innerBounds.lineIntersections(u.x, u.y, v.x, v.y);
+                        if (ints.length > 0) {
+                            debugger;
+                        }
+                    })
+                }
+            })
+            return lineData;
+        }
+
+        //The link source and target may be just a node index, or they may be references to nodes themselves.
+        function getSourceIndex(e) {
+            return typeof e.source === 'number' ? e.source : e.source.index;
+        }
+
+        //The link source and target may be just a node index, or they may be references to nodes themselves.
+        function getTargetIndex(e) {
+            return typeof e.target === 'number' ? e.target : e.target.index;
+        }
+        // Get a string ID for a given link.
+        adaptor.linkId = function (e) {
+            return getSourceIndex(e) + "-" + getTargetIndex(e);
+        }
+
+        return adaptor;
+    };
+
+    // The fixed property has three bits:
+    // Bit 1 can be set externally (e.g., d.fixed = true) and show persist.
+    // Bit 2 stores the dragging state, from mousedown to mouseup.
+    // Bit 3 stores the hover state, from mouseover to mouseout.
+    // Dragend is a special case: it also clears the hover state.
+
+    function colaDragstart(d) {
+        d.fixed |= 2; // set bit 2
+        d.px = d.x, d.py = d.y; // set velocity to zero
+    }
+
+    function colaDragend(d) {
+        d.fixed &= ~6; // unset bits 2 and 3
+        //d.fixed = 0;
+    }
+
+    function colaMouseover(d) {
+        d.fixed |= 4; // set bit 3
+        d.px = d.x, d.py = d.y; // set velocity to zero
+    }
+
+    function colaMouseout(d) {
+        d.fixed &= ~4; // unset bit 3
+    }
+    return cola;
+})(cola || (cola = {}));
+//Based on js_bintrees:
+//
+//https://github.com/vadimg/js_bintrees
+//
+//Copyright (C) 2011 by Vadim Graboys
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in
+//all copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//THE SOFTWARE.
+
+RBTree = (function (window) {
+var global = window;
+var require = function(name) {
+    var fn = require.m[name];
+    if (fn.mod) {
+        return fn.mod.exports;
+    }
+
+    var mod = fn.mod = { exports: {} };
+    fn(mod, mod.exports);
+    return mod.exports;
+};
+
+require.m = {};
+require.m['./treebase'] = function(module, exports) {
+
+function TreeBase() {}
+
+// removes all nodes from the tree
+TreeBase.prototype.clear = function() {
+    this._root = null;
+    this.size = 0;
+};
+
+// returns node data if found, null otherwise
+TreeBase.prototype.find = function(data) {
+    var res = this._root;
+
+    while(res !== null) {
+        var c = this._comparator(data, res.data);
+        if(c === 0) {
+            return res.data;
+        }
+        else {
+            res = res.get_child(c > 0);
+        }
+    }
+
+    return null;
+};
+
+// returns iterator to node if found, null otherwise
+TreeBase.prototype.findIter = function(data) {
+    var res = this._root;
+    var iter = this.iterator();
+
+    while(res !== null) {
+        var c = this._comparator(data, res.data);
+        if(c === 0) {
+            iter._cursor = res;
+            return iter;
+        }
+        else {
+            iter._ancestors.push(res);
+            res = res.get_child(c > 0);
+        }
+    }
+
+    return null;
+};
+
+// Returns an interator to the tree node immediately before (or at) the element
+TreeBase.prototype.lowerBound = function(data) {
+    return this._bound(data, this._comparator);
+};
+
+// Returns an interator to the tree node immediately after (or at) the element
+TreeBase.prototype.upperBound = function(data) {
+    var cmp = this._comparator;
+
+    function reverse_cmp(a, b) {
+        return cmp(b, a);
+    }
+
+    return this._bound(data, reverse_cmp);
+};
+
+// returns null if tree is empty
+TreeBase.prototype.min = function() {
+    var res = this._root;
+    if(res === null) {
+        return null;
+    }
+
+    while(res.left !== null) {
+        res = res.left;
+    }
+
+    return res.data;
+};
+
+// returns null if tree is empty
+TreeBase.prototype.max = function() {
+    var res = this._root;
+    if(res === null) {
+        return null;
+    }
+
+    while(res.right !== null) {
+        res = res.right;
+    }
+
+    return res.data;
+};
+
+// returns a null iterator
+// call next() or prev() to point to an element
+TreeBase.prototype.iterator = function() {
+    return new Iterator(this);
+};
+
+// calls cb on each node's data, in order
+TreeBase.prototype.each = function(cb) {
+    var it=this.iterator(), data;
+    while((data = it.next()) !== null) {
+        cb(data);
+    }
+};
+
+// calls cb on each node's data, in reverse order
+TreeBase.prototype.reach = function(cb) {
+    var it=this.iterator(), data;
+    while((data = it.prev()) !== null) {
+        cb(data);
+    }
+};
+
+// used for lowerBound and upperBound
+TreeBase.prototype._bound = function(data, cmp) {
+    var cur = this._root;
+    var iter = this.iterator();
+
+    while(cur !== null) {
+        var c = this._comparator(data, cur.data);
+        if(c === 0) {
+            iter._cursor = cur;
+            return iter;
+        }
+        iter._ancestors.push(cur);
+        cur = cur.get_child(c > 0);
+    }
+
+    for(var i=iter._ancestors.length - 1; i >= 0; --i) {
+        cur = iter._ancestors[i];
+        if(cmp(data, cur.data) > 0) {
+            iter._cursor = cur;
+            iter._ancestors.length = i;
+            return iter;
+        }
+    }
+
+    iter._ancestors.length = 0;
+    return iter;
+};
+
+
+function Iterator(tree) {
+    this._tree = tree;
+    this._ancestors = [];
+    this._cursor = null;
+}
+
+Iterator.prototype.data = function() {
+    return this._cursor !== null ? this._cursor.data : null;
+};
+
+// if null-iterator, returns first node
+// otherwise, returns next node
+Iterator.prototype.next = function() {
+    if(this._cursor === null) {
+        var root = this._tree._root;
+        if(root !== null) {
+            this._minNode(root);
+        }
+    }
+    else {
+        if(this._cursor.right === null) {
+            // no greater node in subtree, go up to parent
+            // if coming from a right child, continue up the stack
+            var save;
+            do {
+                save = this._cursor;
+                if(this._ancestors.length) {
+                    this._cursor = this._ancestors.pop();
+                }
+                else {
+                    this._cursor = null;
+                    break;
+                }
+            } while(this._cursor.right === save);
+        }
+        else {
+            // get the next node from the subtree
+            this._ancestors.push(this._cursor);
+            this._minNode(this._cursor.right);
+        }
+    }
+    return this._cursor !== null ? this._cursor.data : null;
+};
+
+// if null-iterator, returns last node
+// otherwise, returns previous node
+Iterator.prototype.prev = function() {
+    if(this._cursor === null) {
+        var root = this._tree._root;
+        if(root !== null) {
+            this._maxNode(root);
+        }
+    }
+    else {
+        if(this._cursor.left === null) {
+            var save;
+            do {
+                save = this._cursor;
+                if(this._ancestors.length) {
+                    this._cursor = this._ancestors.pop();
+                }
+                else {
+                    this._cursor = null;
+                    break;
+                }
+            } while(this._cursor.left === save);
+        }
+        else {
+            this._ancestors.push(this._cursor);
+            this._maxNode(this._cursor.left);
+        }
+    }
+    return this._cursor !== null ? this._cursor.data : null;
+};
+
+Iterator.prototype._minNode = function(start) {
+    while(start.left !== null) {
+        this._ancestors.push(start);
+        start = start.left;
+    }
+    this._cursor = start;
+};
+
+Iterator.prototype._maxNode = function(start) {
+    while(start.right !== null) {
+        this._ancestors.push(start);
+        start = start.right;
+    }
+    this._cursor = start;
+};
+
+module.exports = TreeBase;
+
+};
+require.m['__main__'] = function(module, exports) {
+
+var TreeBase = require('./treebase');
+
+function Node(data) {
+    this.data = data;
+    this.left = null;
+    this.right = null;
+    this.red = true;
+}
+
+Node.prototype.get_child = function(dir) {
+    return dir ? this.right : this.left;
+};
+
+Node.prototype.set_child = function(dir, val) {
+    if(dir) {
+        this.right = val;
+    }
+    else {
+        this.left = val;
+    }
+};
+
+function RBTree(comparator) {
+    this._root = null;
+    this._comparator = comparator;
+    this.size = 0;
+}
+
+RBTree.prototype = new TreeBase();
+
+// returns true if inserted, false if duplicate
+RBTree.prototype.insert = function(data) {
+    var ret = false;
+
+    if(this._root === null) {
+        // empty tree
+        this._root = new Node(data);
+        ret = true;
+        this.size++;
+    }
+    else {
+        var head = new Node(undefined); // fake tree root
+
+        var dir = 0;
+        var last = 0;
+
+        // setup
+        var gp = null; // grandparent
+        var ggp = head; // grand-grand-parent
+        var p = null; // parent
+        var node = this._root;
+        ggp.right = this._root;
+
+        // search down
+        while(true) {
+            if(node === null) {
+                // insert new node at the bottom
+                node = new Node(data);
+                p.set_child(dir, node);
+                ret = true;
+                this.size++;
+            }
+            else if(is_red(node.left) && is_red(node.right)) {
+                // color flip
+                node.red = true;
+                node.left.red = false;
+                node.right.red = false;
+            }
+
+            // fix red violation
+            if(is_red(node) && is_red(p)) {
+                var dir2 = ggp.right === gp;
+
+                if(node === p.get_child(last)) {
+                    ggp.set_child(dir2, single_rotate(gp, !last));
+                }
+                else {
+                    ggp.set_child(dir2, double_rotate(gp, !last));
+                }
+            }
+
+            var cmp = this._comparator(node.data, data);
+
+            // stop if found
+            if(cmp === 0) {
+                break;
+            }
+
+            last = dir;
+            dir = cmp < 0;
+
+            // update helpers
+            if(gp !== null) {
+                ggp = gp;
+            }
+            gp = p;
+            p = node;
+            node = node.get_child(dir);
+        }
+
+        // update root
+        this._root = head.right;
+    }
+
+    // make root black
+    this._root.red = false;
+
+    return ret;
+};
+
+// returns true if removed, false if not found
+RBTree.prototype.remove = function(data) {
+    if(this._root === null) {
+        return false;
+    }
+
+    var head = new Node(undefined); // fake tree root
+    var node = head;
+    node.right = this._root;
+    var p = null; // parent
+    var gp = null; // grand parent
+    var found = null; // found item
+    var dir = 1;
+
+    while(node.get_child(dir) !== null) {
+        var last = dir;
+
+        // update helpers
+        gp = p;
+        p = node;
+        node = node.get_child(dir);
+
+        var cmp = this._comparator(data, node.data);
+
+        dir = cmp > 0;
+
+        // save found node
+        if(cmp === 0) {
+            found = node;
+        }
+
+        // push the red node down
+        if(!is_red(node) && !is_red(node.get_child(dir))) {
+            if(is_red(node.get_child(!dir))) {
+                var sr = single_rotate(node, dir);
+                p.set_child(last, sr);
+                p = sr;
+            }
+            else if(!is_red(node.get_child(!dir))) {
+                var sibling = p.get_child(!last);
+                if(sibling !== null) {
+                    if(!is_red(sibling.get_child(!last)) && !is_red(sibling.get_child(last))) {
+                        // color flip
+                        p.red = false;
+                        sibling.red = true;
+                        node.red = true;
+                    }
+                    else {
+                        var dir2 = gp.right === p;
+
+                        if(is_red(sibling.get_child(last))) {
+                            gp.set_child(dir2, double_rotate(p, last));
+                        }
+                        else if(is_red(sibling.get_child(!last))) {
+                            gp.set_child(dir2, single_rotate(p, last));
+                        }
+
+                        // ensure correct coloring
+                        var gpc = gp.get_child(dir2);
+                        gpc.red = true;
+                        node.red = true;
+                        gpc.left.red = false;
+                        gpc.right.red = false;
+                    }
+                }
+            }
+        }
+    }
+
+    // replace and remove if found
+    if(found !== null) {
+        found.data = node.data;
+        p.set_child(p.right === node, node.get_child(node.left === null));
+        this.size--;
+    }
+
+    // update root and make it black
+    this._root = head.right;
+    if(this._root !== null) {
+        this._root.red = false;
+    }
+
+    return found !== null;
+};
+
+function is_red(node) {
+    return node !== null && node.red;
+}
+
+function single_rotate(root, dir) {
+    var save = root.get_child(!dir);
+
+    root.set_child(!dir, save.get_child(dir));
+    save.set_child(dir, root);
+
+    root.red = true;
+    save.red = false;
+
+    return save;
+}
+
+function double_rotate(root, dir) {
+    root.set_child(!dir, single_rotate(root.get_child(!dir), !dir));
+    return single_rotate(root, dir);
+}
+
+module.exports = RBTree;
+};
+return require('__main__');
+})(window);
+
+
+var cola;
+(function (cola) {
+    var applyPacking = {}
+    applyPacking.PADDING = 10;
+    applyPacking.GOLDEN_SECTION = (1 + Math.sqrt(5)) / 2;
+    applyPacking.FLOAT_EPSILON = 0.0001;
+    applyPacking.MAX_INERATIONS = 100;
+
+    // assign x, y to nodes while using box packing algorithm for disconnected graphs
+    cola.applyPacking = function (graphs, w, h, node_size, desired_ratio){
+
+        var init_x = 0,
+            init_y = 0,
+
+            svg_width = w,
+            svg_height = h,
+
+            desired_ratio = typeof desired_ratio !== 'undefined' ? desired_ratio : 1,
+            node_size = typeof node_size !== 'undefined' ? node_size : 0,
+
+            real_width = 0,
+            real_height = 0,
+            min_width = 0,
+
+            global_bottom = 0,
+            line = [];
+	  
+        if (graphs.length == 0)
+            return;
+
+        /// that would take care of single nodes problem
+        // graphs.forEach(function (g) {
+        //     if (g.array.length == 1) {
+        //         g.array[0].x = 0;
+        //         g.array[0].y = 0;
+        //     }
+        // });
+
+        calculate_bb(graphs);
+        apply(graphs);
+        put_nodes_to_right_positions(graphs);
+
+        // get bounding boxes for all separate graphs
+        function calculate_bb(graphs){
+
+            graphs.forEach(function(g) { 
+                calculate_single_bb(g)
+            });
+
+            function calculate_single_bb(graph){
+                var min_x = Number.MAX_VALUE, min_y = Number.MAX_VALUE,
+                 max_x = 0, max_y = 0;
+
+                graph.array.forEach(function(v){
+                    var w = typeof v.width !== 'undefined' ? v.width : node_size;
+                    var h = typeof v.height !== 'undefined' ? v.height : node_size;
+                    w /= 2;
+                    h /= 2;
+                    max_x = Math.max(v.x + w, max_x);
+                    min_x = Math.min(v.x - w, min_x);
+                    max_y = Math.max(v.y + h, max_y);
+                    min_y = Math.min(v.y - h, min_y);
+                });
+
+                graph.width = max_x - min_x;
+                graph.height = max_y - min_y;
+            }
+        }
+
+        function plot(data, left, right, opt_x, opt_y) {
+                    // plot the cost function
+            var plot_svg = d3.select("body").append("svg")
+                .attr("width", function(){return 2 * (right - left);})
+                .attr("height", 200);
+
+
+            var x = d3.time.scale().range([0, 2 * (right - left)]);
+
+            var xAxis = d3.svg.axis().scale(x).orient("bottom");
+            plot_svg.append("g").attr("class", "x axis")
+                .attr("transform", "translate(0, 199)")
+                .call(xAxis);
+
+            var lastX = 0;
+            var lastY = 0;
+            var value = 0;
+            for (var r = left; r < right; r += 1){
+                value = step(data, r);
+                // value = 1;
+
+                plot_svg.append("line").attr("x1", 2 * (lastX - left))
+                    .attr("y1", 200 - 30 * lastY)
+                    .attr("x2", 2 * r - 2 * left)
+                    .attr("y2", 200 - 30 * value)
+                    .style("stroke", "rgb(6,120,155)");
+
+                lastX = r;
+                lastY = value;
+            }
+
+            plot_svg.append("circle").attr("cx", 2 * opt_x - 2 * left).attr("cy", 200 - 30 * opt_y)
+                .attr("r", 5).style('fill', "rgba(0,0,0,0.5)");
+            
+        }
+
+        // actuall assigning of position to nodes
+        function put_nodes_to_right_positions(graphs){
+            graphs.forEach(function(g){
+                // calculate current graph center:
+                var center = {x: 0, y: 0};
+                
+                g.array.forEach(function(node){
+                    center.x += node.x;
+                    center.y += node.y;
+                });
+                
+                center.x /= g.array.length;
+                center.y /= g.array.length;
+
+                // calculate current top left corner:
+                var corner = { x: center.x - g.width/2, y: center.y - g.height/2 };
+                var offset = { x: g.x - corner.x, y: g.y - corner.y };
+
+                // put nodes:
+                g.array.forEach(function(node){
+                    node.x = node.x + offset.x + svg_width/2 - real_width/2;
+                    node.y = node.y + offset.y + svg_height/2 - real_height/2;
+                });
+            });
+        }
+
+        // starts box packing algorithm
+        // desired ratio is 1 by default
+        function apply(data, desired_ratio){
+            var curr_best_f = Number.POSITIVE_INFINITY;
+            var curr_best = 0;
+            data.sort(function (a, b) { return b.height - a.height; });
+
+            min_width = data.reduce(function(a, b) {
+                return a.width < b.width ? a.width : b.width;
+            });
+
+            var left = x1 = min_width;
+            var right = x2 = get_entire_width(data);
+            var iterationCounter = 0;
+            
+            var f_x1 = Number.MAX_VALUE;
+            var f_x2 = Number.MAX_VALUE;
+            var flag = -1; // determines which among f_x1 and f_x2 to recompute
+
+
+            var dx = Number.MAX_VALUE;
+            var df = Number.MAX_VALUE;
+
+            while (( dx > min_width) || df > applyPacking.FLOAT_EPSILON ) {
+
+                if (flag != 1) {
+                    var x1 = right - (right - left) / applyPacking.GOLDEN_SECTION;
+                    var f_x1 = step(data, x1);
+                } 
+                if (flag != 0) {
+                    var x2 = left + (right - left) / applyPacking.GOLDEN_SECTION; 
+                    var f_x2 = step(data, x2);
+                }
+
+                dx = Math.abs(x1 - x2);
+                df = Math.abs(f_x1 - f_x2);
+
+                if (f_x1 < curr_best_f) {
+                    curr_best_f = f_x1;
+                    curr_best = x1;
+                }
+
+                if (f_x2 < curr_best_f) {
+                    curr_best_f = f_x2;
+                    curr_best = x2;
+                }
+
+                if (f_x1 > f_x2) {
+                    left = x1;
+                    x1 = x2;
+                    f_x1 = f_x2;
+                    flag = 1;
+                } else {
+                    right = x2;
+                    x2 = x1;
+                    f_x2 = f_x1;
+                    flag = 0;
+                }
+
+                if (iterationCounter++ > 100) {
+                    break;
+                }  
+            }
+            // plot(data, min_width, get_entire_width(data), curr_best, curr_best_f);
+            step(data, curr_best);
+        }
+
+        // one iteration of the optimization method
+        // (gives a proper, but not necessarily optimal packing)
+        function step(data, max_width){
+            line = [];
+            real_width = 0;
+            real_height = 0;
+            global_bottom = init_y;
+
+            for (var i = 0; i < data.length; i++){
+                var o = data[i];
+                put_rect(o, max_width);
+            }
+
+            return Math.abs(get_real_ratio() - desired_ratio);
+        }
+
+        // looking for a position to one box 
+        function put_rect(rect, max_width){
+            
+
+            var parent = undefined;
+
+            for (var i = 0; i < line.length; i++){
+                if ((line[i].space_left >= rect.height) && (line[i].x + line[i].width + rect.width + applyPacking.PADDING - max_width) <= applyPacking.FLOAT_EPSILON){
+                    parent = line[i];
+                    break;
+                }
+            }
+
+            line.push(rect);
+
+            if (parent !== undefined){
+                rect.x = parent.x + parent.width + applyPacking.PADDING;
+                rect.y = parent.bottom;
+                rect.space_left = rect.height;
+                rect.bottom = rect.y;
+                parent.space_left -= rect.height + applyPacking.PADDING;
+                parent.bottom += rect.height + applyPacking.PADDING;
+            } else {
+                rect.y = global_bottom;
+                global_bottom += rect.height + applyPacking.PADDING;
+                rect.x = init_x;
+                rect.bottom = rect.y;
+                rect.space_left = rect.height;
+            }
+
+            if (rect.y + rect.height - real_height > -applyPacking.FLOAT_EPSILON) real_height = rect.y + rect.height - init_y;
+            if (rect.x + rect.width - real_width > -applyPacking.FLOAT_EPSILON) real_width = rect.x + rect.width - init_x;
+        };
+
+        function get_entire_width(data){
+            var width = 0;
+            data.forEach(function (d) {return width += d.width + applyPacking.PADDING;});
+            return width;
+        }
+
+        function get_real_ratio(){
+            return (real_width / real_height);
+        }
+    }
+
+    // seraration of disconnected graphs
+    // returns an array of {}
+    cola.separateGraphs = function(nodes, links){
+        var marks = {};
+        var ways = {};
+        graphs = [];
+        var clusters = 0;
+
+        for (var i = 0; i < links.length; i++){
+            var link = links[i];
+            var n1 = link.source;
+            var n2 = link.target;
+            if (ways[n1.index]) 
+                ways[n1.index].push(n2);
+            else
+                ways[n1.index] = [n2];
+            
+            if (ways[n2.index]) 
+                ways[n2.index].push(n1);
+            else
+                ways[n2.index] = [n1];
+        }
+
+        for (var i = 0; i < nodes.length; i++){
+            var node = nodes[i];
+            if (marks[node.index]) continue;
+            explore_node(node, true);
+        }
+
+        function explore_node(n, is_new){
+            if (marks[n.index] !== undefined) return;
+            if (is_new) {
+                clusters++;
+                graphs.push({array:[]});
+            }
+            marks[n.index] = clusters;
+            graphs[clusters - 1].array.push(n);
+            var adjacent = ways[n.index];
+            if (!adjacent) return;
+        
+            for (var j = 0; j < adjacent.length; j++){
+                explore_node(adjacent[j], false);
+            }
+        }
+    
+        return graphs;
+    }
+    return cola;
+})(cola || (cola = {}))

--- a/WebCola/examples/SucroseBreakdown.html
+++ b/WebCola/examples/SucroseBreakdown.html
@@ -47,7 +47,7 @@
     <h1>Metabolic Pathway: Sucrose Breakdown</h1>
 <script src="../extern/d3.v3.js"></script>
 <script src="../cola.v3.min.js"></script>
-    <!--<script src="../src/d3adaptor.js"></script>-->
+    <!--<script src="../src/adaptor.js"></script>-->
 <script>
     var width = 800,
         height = 520;

--- a/WebCola/examples/disconnected_graphs.html
+++ b/WebCola/examples/disconnected_graphs.html
@@ -21,7 +21,7 @@
 
 <body>
 	<script src="../extern/d3.v3.js"></script>
-    <script src="../src/d3adaptor.js"></script>
+    <script src="../src/adaptor.js"></script>
     <script src="../cola.v3.min.js"></script>
     <h1>Packing of Disconnected Components</h1>
 <script>

--- a/WebCola/examples/friendnetworks.html
+++ b/WebCola/examples/friendnetworks.html
@@ -64,7 +64,7 @@
     <p />
 <script src="../extern/d3.v3.js"></script>
     <script src="../cola.v3.min.js"></script>
-    <script src="../src/d3adaptor.js"></script>
+    <script src="../src/adaptor.js"></script>
     <script src="../src/linklengths.js"></script>
 <script>
     var width = 280,

--- a/WebCola/examples/powergraph.html
+++ b/WebCola/examples/powergraph.html
@@ -56,7 +56,7 @@
     <script src="../cola.v3.min.js"></script>    
     <script src="../extern/jquery-1.10.2.min.js"></script>
 
-    <!--<script src="../src/d3adaptor.js"></script>
+    <!--<script src="../src/adaptor.js"></script>
     <script src="../src/descent.js"></script>
     <script src="../src/vpsc.js"></script>
     <script src="../src/rectangle.js"></script>-->

--- a/WebCola/examples/pretrippowergraph.html
+++ b/WebCola/examples/pretrippowergraph.html
@@ -44,7 +44,7 @@
     <script src="../cola.v3.min.js"></script>    
     <script src="../extern/jquery-1.10.2.min.js"></script>
     <script src="../src/powergraph.js"></script>
-    <script src="../src/d3adaptor.js"></script>
+    <script src="../src/adaptor.js"></script>
 
     <!--<script src="../src/descent.js"></script>
     <script src="../src/vpsc.js"></script>

--- a/WebCola/examples/statemachinepowergraph.html
+++ b/WebCola/examples/statemachinepowergraph.html
@@ -44,7 +44,7 @@
     <script src="../cola.v3.min.js"></script>    
     <script src="../extern/jquery-1.10.2.min.js"></script>
     <script src="../src/powergraph.js"></script>
-    <script src="../src/d3adaptor.js"></script>
+    <script src="../src/adaptor.js"></script>
 
     <!--<script src="../src/descent.js"></script>
     <script src="../src/vpsc.js"></script>

--- a/WebCola/examples/tetrisbugpowergraph.html
+++ b/WebCola/examples/tetrisbugpowergraph.html
@@ -39,7 +39,7 @@
     <script src="../cola.v3.min.js"></script>    
     <script src="../extern/jquery-1.10.2.min.js"></script>
     <script src="../src/powergraph.js"></script>
-    <script src="../src/d3adaptor.js"></script>
+    <script src="../src/adaptor.js"></script>
 
     <!--<script src="../src/descent.js"></script>
     <script src="../src/vpsc.js"></script>

--- a/WebCola/test/test.html
+++ b/WebCola/test/test.html
@@ -8,7 +8,7 @@
     <script src="tests.js"></script>
     <script src="vpsctests.js"></script>
 
-    <script src="../src/d3adaptor.js"></script>
+    <script src="../src/adaptor.js"></script>
     <script src="../src/rectangle.js"></script>
     <script src="../src/vpsc.js"></script>
     <script src="../src/shortestpaths.js"></script>

--- a/WebCola/test/tests.js
+++ b/WebCola/test/tests.js
@@ -1,5 +1,5 @@
 ﻿/// <reference path="d3.v3.min.js"/>
-/// <reference path="../src/d3adaptor.js"/>
+/// <reference path="../src/adaptor.js"/>
 /// <reference path="../src/shortestpaths.js"/>
 /// <reference path="../src/descent.js"/>
 /// <reference path="../src/cola.vpsc.js"/>


### PR DESCRIPTION
This adds support for a generic adaptor that can be used with any graph JS visualisation library.  The `d3adaptor` is a derivative of `cola.adaptor`, and isolates all D3-related code.

I've also updated project references to the new `adaptor.js` file which replaces `d3adaptor.js`.  

I can't run the tests, as they seem to require Visual Studio to compile the TS rather than Grunt.  However, the Grunt build tasks still work and I've confirmed that the new `cola.d3adaptor` works with the `ariel.html` example after building.
