### PR TITLE
point bower/npm etc. at the latest packaged cola.v3.min.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Tim Dwyer"
   ],
   "description": "Javascript constraint based layout for high-quality graph visualization and exploration",
-  "main": "WebCola/cola.v2.min.js",
+  "main": "WebCola/cola.v3.min.js",
   "keywords": [
     "d3",
     "graph",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "async": "~0.6.2"
   },
   "description": "WebCola =======",
-  "main": "Gruntfile.js",
+  "main": "WebCola/cola.v3.min.js",
   "dependencies": {},
   "scripts": {
     "test": "grunt full"


### PR DESCRIPTION
Gruntfile.js was not a valid entry point and was breaking browserify.