### PR TITLE
Bump bower.json and package.json to 3.1.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "webcola",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "homepage": "https://github.com/tgdwyer/WebCola",
   "authors": [
     "Tim Dwyer"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webcola",
-  "version": "3.0.1",
+  "version": "3.1.1",
   "devDependencies": {
     "async": "~0.6.2",
     "grunt": "~0.4.2",


### PR DESCRIPTION
CommonJS support is still not there (see #44), but we should at least have `bower.json` and `package.json` in sync.

cf91f81 put the version numbers out of sync, and the fix in 1cf5dcc came after 3.1.0.

See https://github.com/tgdwyer/WebCola/issues/100 for more info.