### PR TITLE
Fixes in the power graph layout

### DIFF
--- a/WebCola/src/gridrouter.ts
+++ b/WebCola/src/gridrouter.ts
@@ -477,7 +477,7 @@ module cola {
         // for an orthogonal path described by a sequence of points, create a list of segments
         // if consecutive segments would make a straight line they are merged into a single segment
         // segments are over cloned points, not the original vertices
-        static makeSegments(path: geom.Point[]): geom.Point[][] {
+        static makeSegments(path: any): geom.Point[][] {
             function copyPoint(p: geom.Point) {
                 return <geom.Point>{ x: p.x, y: p.y };
             }
@@ -490,6 +490,12 @@ module cola {
                     segments.push([a, b]);
                     a = b;
                 }
+            }
+            if (path.reversed) {
+                segments.reverse(); // reverse order of segments
+                segments.forEach(function(segment) {
+                    segment.reverse();  // reverse each segment
+                });
             }
             return segments;
         }

--- a/WebCola/src/gridrouter.ts
+++ b/WebCola/src/gridrouter.ts
@@ -443,8 +443,9 @@ module cola {
                         f.reversed = true;
                         lcs = new cola.LongestCommonSubsequence(e, f);
                     }
-                    if (lcs.length === e.length || lcs.length === f.length) {
-                        // the edges are completely co-linear so make an arbitrary ordering decision
+                    if ((lcs.si <= 0 || lcs.ti <= 0) &&
+                        (lcs.si + lcs.length >= e.length || lcs.ti + lcs.length >= f.length)) {
+                        // the paths do not diverge, so make an arbitrary ordering decision
                         edgeOrder.push({ l: i, r: j });
                         continue;
                     }

--- a/WebCola/src/powergraph.ts
+++ b/WebCola/src/powergraph.ts
@@ -98,6 +98,7 @@ module cola.powergraph {
         }
 
         private rootMerges(k: number = 0): {
+            id: number;
             nEdges: number;
             a: Module;
             b: Module;
@@ -109,7 +110,8 @@ module cola.powergraph {
             for (var i = 0, i_ = n - 1; i < i_; ++i) {
                 for (var j = i+1; j < n; ++j) {
                     var a = rs[i], b = rs[j];
-                    merges[ctr++] = { nEdges: this.nEdges(a, b), a: a, b: b };
+                    merges[ctr] = { id: ctr, nEdges: this.nEdges(a, b), a: a, b: b };
+                    ctr++;
                 }
             }
             return merges;
@@ -119,7 +121,7 @@ module cola.powergraph {
             for (var i = 0; i < this.roots.length; ++i) {
                 // Handle single nested module case
                 if (this.roots[i].modules().length < 2) continue;
-                var ms = this.rootMerges(i).sort((a, b) => a.nEdges - b.nEdges);
+                var ms = this.rootMerges(i).sort((a, b) => a.nEdges == b.nEdges ? a.id - b.id : a.nEdges - b.nEdges);
                 var m = ms[0];
                 if (m.nEdges >= this.R) continue;
                 this.merge(m.a, m.b, i);


### PR DESCRIPTION
This pull request contains three fixes:

* The JavaScript `sort()` function is stable in Firefox/IE, but not in Chrome. This resulted in different behaviour for those browsers.
* There was a missing case in `orderEdges()` in the grid router, causing out-of-bounds array accesses, which resulted in an error.
* Edges that were reversed by the grid router (`routeEdges()`) were not reversed back again.