### PR TITLE
Fix padding on nested groups (power graph example)

### DIFF
--- a/WebCola/examples/dotpowergraph.ts
+++ b/WebCola/examples/dotpowergraph.ts
@@ -165,10 +165,10 @@ module dotpowergraph {
             .attr("width", d=> d.routerNode.bounds.width())
             .attr("height", d=> d.routerNode.bounds.height());
 
-        svg.selectAll(".group").transition().attr('x', d => d.routerNode.bounds.x)
-            .attr('y', d => d.routerNode.bounds.y)
-            .attr('width', d => d.routerNode.bounds.width())
-            .attr('height', d => d.routerNode.bounds.height())
+        svg.selectAll(".group").transition().attr('x', (d, i) => gridrouter.groups[i].rect.x)
+            .attr('y', (d, i) => gridrouter.groups[i].rect.y)
+            .attr('width', (d, i) => gridrouter.groups[i].rect.width())
+            .attr('height', (d, i) => gridrouter.groups[i].rect.height())
             .style("fill", (d, i) => color(i));
     }
 


### PR DESCRIPTION
The example graph (`n26e35.dot`) did not contain nested groups, so there is no visual change in the example. However, if you use a graph that results in nested groups, the padding was missing around groups that contained other groups inside them. This pull request fixes that issue.