### PR TITLE
Addresses Cytoscape.js/Cola.js demo issues etc.

### DIFF
--- a/WebCola/examples/cygenegene.css
+++ b/WebCola/examples/cygenegene.css
@@ -39,3 +39,8 @@ p {
   width: 3em;
   margin-right: 0.25em;
 }
+
+a,
+a:hover {
+  color: #62daea;
+}

--- a/WebCola/examples/cygenegene.html
+++ b/WebCola/examples/cygenegene.html
@@ -16,8 +16,13 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-slider/4.10.3/bootstrap-slider.min.js"></script>
-    <!-- load from cy cdn for ver bundled w/ cytoscape.js <script src="https://cytoscape.github.io/cytoscape.js/api/cytoscape.js-latest/cola.v3.min.js"></script>-->
-    <script src="../cola.min.js"></script>
+    
+    <!-- load from cy cdn for ver bundled w/ cytoscape.js -->
+    <script src="https://cytoscape.github.io/cytoscape.js/api/cytoscape.js-latest/cola.v3.min.js"></script>
+    
+    <!-- load local version from build -->
+    <!-- <script src="../cola.min.js"></script> -->
+    
     <script src="http://cytoscape.github.io/cytoscape.js/api/cytoscape.js-latest/cytoscape.min.js"></script>
     
     <script src="cygenegene.js"></script>

--- a/WebCola/examples/cygenegene.html
+++ b/WebCola/examples/cygenegene.html
@@ -30,6 +30,11 @@
         <span class="label label-info">Cola.js/Cytoscape.js demo</span>
 
         <p>This is a demo of a graph of gene-gene interactions that uses Cola.js for layout and Cytoscape.js for its graph model and visualisation.  Use the controls below to alter the Cola.js layout parameters.</p>
+        <p>
+          Data by <a href="http://genemania.org">GeneMANIA</a><br/>
+          Visualisation by <a href="http://js.cytoscape.org">Cytoscape.js</a><br/>
+          Layout by <a href="http://marvl.infotech.monash.edu/webcola/">Cola.js</a>
+        </p>
       </div>
       
     </div>

--- a/WebCola/index.html
+++ b/WebCola/index.html
@@ -134,7 +134,7 @@
     <p><b>cola.js</b> (A.K.A. "WebCoLa") is an <a href="https://raw.github.com/tgdwyer/WebCola/master/LICENSE">open-source</a> JavaScript library for arranging your HTML5 documents and diagrams using constraint-based optimization techniques.
 
     <p>
-        It works well with libraries like <a href="http://d3js.org">D3.js</a> and <a href="http://www.svgjs.com">svg.js</a>.
+        It works well with libraries like <a href="http://d3js.org">D3.js</a>, <a href="http://www.svgjs.com">svg.js</a>, and <a href="http://js.cytoscape.org">Cytoscape.js</a>.
         The core layout is based on a complete rewrite in Javascript of the C++ <a href="http://adaptagrams.org">libcola</a> library.
     </p>
 
@@ -152,11 +152,21 @@
                 <li>Nicholas Smith</li>
                 <li><a href="https://github.com/bollwyvl">bollwyvl</a></li>
                 <li><a href="https://github.com/Craxic">Matt Ready</a></li>
+                <li><a href="https://github.com/maxkfranz">Max Franz</a></li>
             </ul> 
         </p>
     </aside>
+    
     <p>
-        It has an adaptor for d3.js that allows you to use cola as a drop-in replacement for the <a href="https://github.com/mbostock/d3/wiki/Force-Layout">D3 force layout</a>.
+        Cytoscape.js has <a href="http://js.cytoscape.org/#layouts/cola">full support for Cola.js</a>.  Cytoscape.js has a full graph
+        theory model, highly customisable styling, gesture support, and layouts &mdash; such that Cola.js can be run in Cytoscape.js
+        in a single line of code:
+    </p>
+    
+<pre><code>cy.layout({ name: 'cola' /* and maybe some other options */ });</code></pre>
+    
+    <p>
+        It also has an adaptor for d3.js that allows you to use cola as a drop-in replacement for the <a href="https://github.com/mbostock/d3/wiki/Force-Layout">D3 force layout</a>.
         The layout converges to a local optimum unlike the D3 force layout, which forces convergence through a simple annealing strategy.
         Thus, compared to D3 force layout:
         <ul>
@@ -177,7 +187,7 @@
     </aside>    <p>
              cola.js can now (optionally) <a href="examples/unix.html">route edges to avoid intersections with node boundaries</a>.
         </p>
-    <h2>Getting Started</h2>
+    <h2>Getting Started with D3</h2>
         <p>
             Replacing D3 force layout with cola.js is easy.  Include the following in your html:
             <pre><code class="html">&lt;script src="http://marvl.infotech.monash.edu/webcola/cola.v3.min.js"&gt;&lt;/script&gt;</code></pre>


### PR DESCRIPTION
Hi Tim -- This should fix the issue regarding the adaptor error in https://github.com/tgdwyer/WebCola/pull/125 .  I think the website must be using a version of Cola.js prior to my adding back the `cola.adaptor`.  Now, the example uses a snapshot of `cola.js` from the Cytoscape.js public source URLs.  It also adds the links on the demos etc.  -Max