### PR TITLE
Fix assertion failure in Chrome

### DIFF
--- a/WebCola/src/rectangle.ts
+++ b/WebCola/src/rectangle.ts
@@ -202,6 +202,10 @@ module cola.vpsc {
             // open must come before close
             return -1;
         }
+        if (b.isOpen) {
+            // open must come before close
+            return 1;
+        }
         return 0;
     }
 


### PR DESCRIPTION
Chrome fails with an assertion failure in generateContraints() in rectangle.ts, because scanline is not empty at the end of the function. That's because the events get out of order and closes come before opens.

The code works OK in Firefox and IE, I think because their sort function is stable, so the open/close event pairs are kept in order.