### PR TITLE
set node index before it's needed

### DIFF
--- a/WebCola/src/layout.ts
+++ b/WebCola/src/layout.ts
@@ -497,8 +497,6 @@ module cola {
                 w = this._canvasSize[0],
                 h = this._canvasSize[1];
 
-            if (this._linkLengthCalculator) this._linkLengthCalculator();
-
             var x = new Array(N), y = new Array(N);
 
             var G = null;
@@ -512,6 +510,9 @@ module cola {
                 }
                 x[i] = v.x, y[i] = v.y;
             });
+
+            if (this._linkLengthCalculator) this._linkLengthCalculator();
+
             //should we do this to clearly label groups?
             //this._groups.forEach((g, i) => g.groupIndex = i);
 


### PR DESCRIPTION
Here's half of a fix for #134. I've tested it with a simple dummy application but I can also add automated tests if that's helpful.

I did not check in the artifacts; not sure what you prefer @tgdwyer.

The other half of my fix for #134 is a start at some general API documentation here:
https://github.com/tgdwyer/WebCola/wiki/General-API-notes

Please review. Thanks!

Explanation (from the commit message): edge source and target can be specified by integer index or by reference to the node objects. if specified by reference, cola.js needs the node objects to have an `index` member specifying the integer index.

it is already initializing this from the position in the array but it needs to do this before calling the linkLengthCalculator; otherwise lengths will not be applied.