### PR TITLE
commented console asserts which may cause instabilities

### DIFF
--- a/WebCola/cola.js
+++ b/WebCola/cola.js
@@ -1384,7 +1384,9 @@ var cola;
         function generateConstraints(rs, vars, rect, minSep) {
             var i, n = rs.length;
             var N = 2 * n;
-            console.assert(vars.length >= n);
+            /* DEBUG
+                console.assert(vars.length >= n);
+            DEBUG */
             var events = new Array(N);
             for (i = 0; i < n; ++i) {
                 var r = rs[i];
@@ -1420,7 +1422,9 @@ var cola;
                     visitNeighbours("next", "prev", function (u, v) { return makeConstraint(v, u); });
                 }
             }
-            console.assert(scanline.size === 0);
+            /* DEBUG
+                console.assert(scanline.size === 0);
+            DEBUG */
             return cs;
         }
         function findXNeighbours(v, scanline) {


### PR DESCRIPTION
In our project, which must support older browser versions , a bug occurs: 
"<i>Object doesn't support assert</i>"

At https://developer.mozilla.org/en-US/docs/Web/API/console/assert it states: 
"<i>This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user. There may also be large incompatibilities between implementations and the behavior may change in the future.</i>"