### PR TITLE
Add a .npmignore to shrink NPM package size

### DIFF
--- a/WebCola/.npmignore
+++ b/WebCola/.npmignore
@@ -1,0 +1,2 @@
+examples/
+extern/


### PR DESCRIPTION
Webcola is currently a ~20MB tarball; removing these folders from the
package shrinks that to ~225KB.

See
https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package
for documentation.

Note: There are likely other files currently in the package that should be
ignored, but these seemed to be obvious "low-hanging fruit".

Another alternative would be to use the `files` key in `package.json`;
that is a whitelist approach rather than a blacklist.