### PR TITLE
fix npm installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A version suitable for browsers can be found [here](WebCola/cola.js) ([minified]
 You can also install it through npm by first adding it to `package.json`:
 
     "dependencies": {
-      "cola": "tgdwyer/WebCola#master"
+      "webcola": "tgdwyer/WebCola#master"
     }
 Then by running `npm install`.
 


### PR DESCRIPTION
npm installs the module as `webcola`, so the dependency name should match, otherwise `npm install` will warn of an extraneous `webcola` module.

This issue was first observed in #203.