### PR TITLE
Removing a redundant call to addViewNode

### DIFF
--- a/WebCola/examples/browsemovies.html
+++ b/WebCola/examples/browsemovies.html
@@ -105,7 +105,6 @@
     // get first node
     var d = modelgraph.getNode(tmdb.Movie, 550, addViewNode);
     $.when(d).then(function (startNode) {
-        addViewNode(startNode);
         refocus(startNode);
     });
 


### PR DESCRIPTION
It is being called from `getNode`. The extra-call resulted in a duplicated node for the original movie - it's easy to see using a movie with a few casts, like [#17609](https://www.themoviedb.org/movie/17609-antichrist) for example.