### PR TITLE
Proposed fix for #211

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+node_modules/
+WebCola/compiledtypescript.js
+WebCola/doc
+**/*.js.map
+.tscachea
+WebCola/.baseDir.ts
+WebCola/examples/*.js
+.tscache
+WebCola/test/npm-debug.log
+WebCola/test/bundle.js
+WebCola/test/apitests.js

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A version suitable for browsers can be found [here](WebCola/cola.js) ([minified]
 You can also install it through npm by first adding it to `package.json`:
 
     "dependencies": {
-      "webcola": "tgdwyer/WebCola#master"
+      "webcola": "latest"
     }
 Then by running `npm install`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webcola",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "devDependencies": {
     "@types/d3": "^4.5.0",
     "@types/jquery": "^2.0.40",


### PR DESCRIPTION
I have:
- Created `.npmignore` , which must differ from the `.gitignore` as in **not** ignoring the transcribed `.js` files.
- Updated the `README`, since now directly installing the package from the repo will result in errors due to the lack of transcribed `.js` files directly in the repo.
- Bumped the version number

**IMPORTANT**: The package still needs to be published to NPM and then one can test if the `.js` files are present in the `src` folder, as suggested in #211 .