### PR TITLE
bug fix: RBTree NaN positions

### DIFF
--- a/WebCola/src/rectangle.ts
+++ b/WebCola/src/rectangle.ts
@@ -210,7 +210,12 @@ import {RBTree} from './rbtree'
     }
 
     function makeRBTree(): RBTree<Node> {
-        return new RBTree<Node>((a, b) => a.pos - b.pos);
+        return new RBTree<Node>((a, b) => {
+            if (isNaN(a.pos) || isNaN(b.pos)){
+                return 0
+            }
+            return a.pos - b.pos
+        });
     }
 
     interface RectAccessors {


### PR DESCRIPTION
### Description of Changes

Fix a NaN bug causing the RBTree to get caught in an infinite loop.

#### How to reproduce bug:

Bug is possible to reproduce here: [WARNING - INFINITE LOOP POSSIBLE](https://bl.ocks.org/SpyR1014/d82570c509028e6b0a519ef885ab58f0/44a56ba9bfaf4d1bd2cf7e727da414683aba9895).

 - Dragging the network while it is being modified.

Caused by `pos` attribute of the Node getting set to `NaN`.

### Why Should This Be In Core?

I can't find another way to avoid this infinite loop when dealing with dynamic graphs and user interaction.

### Benefits

The avoidance of an infinite loop which can ruin the user experience.

### Possible Drawbacks

I've noticed that with the patch there is still quite a lot of latency when combining the following:

 - Modifying the graph
 - Dragging a node
 - Edge routing

### Comments

I've not included a hacky test to show that this fixes the issue. This can be included if required.

I'm also only committing the fixed change (without building). Do I need to submit the pull request with a new build?

Thank you!