### PR TITLE
move dependencies not needed in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "babel-preset-es2015": "^6.18.0",
     "babelify": "^7.3.0",
     "d3": "^4.5.0",
+    "d3-zoom": "^1.1.4",
     "dts-generator": "^2.0.0",
+    "fullscreen": "^1.1.0",
+    "graphlib-dot": "^0.6.2",
     "grunt": "^1.0.1",
     "grunt-browserify": "^5.0.0",
     "grunt-contrib-connect": "^1.0.2",
@@ -19,6 +22,7 @@
     "grunt-ts": "^6.0.0-beta.3",
     "grunt-typedoc": "^0.2.4",
     "grunt-umd": "~1.7.3",
+    "jquery": "^3.1.1",
     "load-grunt-tasks": "~0.4.0",
     "qunitjs": "^1.23.1",
     "tsify": "^2.0.3",
@@ -53,10 +57,6 @@
   "dependencies": {
     "d3-dispatch": "^1.0.3",
     "d3-drag": "^1.0.4",
-    "d3-timer": "^1.0.5",
-    "d3-zoom": "^1.1.4",
-    "fullscreen": "^1.1.0",
-    "graphlib-dot": "^0.6.2",
-    "jquery": "^3.1.1"
+    "d3-timer": "^1.0.5"
   }
 }


### PR DESCRIPTION
Moves dependencies that were only used in examples to devDependencies since they shouldn't be in the npm package. These were needlessly bloating my app.