### PR TITLE
in .npmignore change WebCola/doc to doc/

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 node_modules/
 WebCola/compiledtypescript.js
-WebCola/doc
+doc/
 WebCola/*.js.map
 .tscachea
 WebCola/.baseDir.ts

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,4 @@ WebCola/*.js.map
 WebCola/.baseDir.ts
 WebCola/examples/*.js
 .tscache
-WebCola/test/npm-debug.log
-WebCola/test/bundle.js
-WebCola/test/apitests.js
+WebCola/test/


### PR DESCRIPTION
doc/ is making the npm package huge (251 megs uncompressed!) and it isn't needed in the npm package. It looks like the .npmignore file tried to address this with `WebCola/doc`, but that directory isn't created. I believe it was intended to be `doc/`

<img width="219" alt="screen shot 2017-05-12 at 12 07 28 pm" src="https://cloud.githubusercontent.com/assets/9285485/26007507/caf80a72-370e-11e7-8338-32bc51df97b1.png">

<img width="361" alt="screen shot 2017-05-12 at 12 29 37 pm" src="https://cloud.githubusercontent.com/assets/9285485/26007506/caf583e2-370e-11e7-8245-2c43d59e26f3.png">

