### PR TITLE
Toolchain fix - missing referenced files in dist folder

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,10 @@
     "sourceMap": true,
     "declaration": true,
     "compileOnSave": false,
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "./WebCola"
   },
-  "files": [
-    "WebCola/index.ts"
+  "include": [
+    "WebCola/src/**/*.ts", "WebCola/*.ts"
   ]
 }


### PR DESCRIPTION
When running npm install I got an error complaining about missing
dist/src/adaptor.js file. Only the output of transpiling
Webcola/index.ts was present in the dist folder. And it wasn't bundled
so index.js contained require references to ./src/adaptor and others.

This change seems to fix this problem. The files that appear in the npm
version will appear in dist when building. I'm still puzzled by how it
could work for anyone else without this.