### PR TITLE
Allow restarting without re-centering graph

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,6 +74,9 @@ module.exports = function (grunt) {
     ts: {
       commonjs: {
         tsconfig: true,
+        options: {
+          inlineSourceMap: true
+        }
       },
       test: {
         src: ['WebCola/test/*.ts', '!WebCola/index.ts', '!WebCola/src/batch.ts'],

--- a/WebCola/src/handledisconnected.ts
+++ b/WebCola/src/handledisconnected.ts
@@ -6,7 +6,7 @@
     };
 
     // assign x, y to nodes while using box packing algorithm for disconnected graphs
-    export function applyPacking(graphs:Array<any>, w, h, node_size, desired_ratio = 1) {
+    export function applyPacking(graphs:Array<any>, w, h, node_size, desired_ratio = 1, centerGraph = true) {
 
         var init_x = 0,
             init_y = 0,
@@ -37,6 +37,9 @@
 
         calculate_bb(graphs);
         apply(graphs, desired_ratio);
+        if(centerGraph) {
+            put_nodes_to_right_positions(graphs);
+        }
 
         // get bounding boxes for all separate graphs
         function calculate_bb(graphs) {
@@ -100,6 +103,32 @@
         //        .attr("r", 5).style('fill', "rgba(0,0,0,0.5)");
 
         //}
+
+        // actual assigning of position to nodes
+        function put_nodes_to_right_positions(graphs) {
+            graphs.forEach(function (g) {
+                // calculate current graph center:
+                var center = { x: 0, y: 0 };
+
+                g.array.forEach(function (node) {
+                    center.x += node.x;
+                    center.y += node.y;
+                });
+
+                center.x /= g.array.length;
+                center.y /= g.array.length;
+
+                // calculate current top left corner:
+                var corner = { x: center.x - g.width / 2, y: center.y - g.height / 2 };
+                var offset = { x: g.x - corner.x + svg_width / 2 - real_width / 2, y: g.y - corner.y + svg_height / 2 - real_height / 2};
+
+                // put nodes:
+                g.array.forEach(function (node) {
+                    node.x += offset.x;
+                    node.y += offset.y;
+                });
+            });
+        }
 
         // starts box packing algorithm
         // desired ratio is 1 by default

--- a/WebCola/src/handledisconnected.ts
+++ b/WebCola/src/handledisconnected.ts
@@ -37,7 +37,7 @@
 
         calculate_bb(graphs);
         apply(graphs, desired_ratio);
-        put_nodes_to_right_positions(graphs);
+        // put_nodes_to_right_positions(graphs);
 
         // get bounding boxes for all separate graphs
         function calculate_bb(graphs) {
@@ -103,30 +103,30 @@
         //}
 
         // actual assigning of position to nodes
-        function put_nodes_to_right_positions(graphs) {
-            graphs.forEach(function (g) {
-                // calculate current graph center:
-                var center = { x: 0, y: 0 };
-
-                g.array.forEach(function (node) {
-                    center.x += node.x;
-                    center.y += node.y;
-                });
-
-                center.x /= g.array.length;
-                center.y /= g.array.length;
-
-                // calculate current top left corner:
-                var corner = { x: center.x - g.width / 2, y: center.y - g.height / 2 };
-                var offset = { x: g.x - corner.x + svg_width / 2 - real_width / 2, y: g.y - corner.y + svg_height / 2 - real_height / 2};
-
-                // put nodes:
-                g.array.forEach(function (node) {
-                    node.x += offset.x;
-                    node.y += offset.y;
-                });
-            });
-        }
+        // function put_nodes_to_right_positions(graphs) {
+        //     graphs.forEach(function (g) {
+        //         // calculate current graph center:
+        //         var center = { x: 0, y: 0 };
+        //
+        //         g.array.forEach(function (node) {
+        //             center.x += node.x;
+        //             center.y += node.y;
+        //         });
+        //
+        //         center.x /= g.array.length;
+        //         center.y /= g.array.length;
+        //
+        //         // calculate current top left corner:
+        //         var corner = { x: center.x - g.width / 2, y: center.y - g.height / 2 };
+        //         var offset = { x: g.x - corner.x + svg_width / 2 - real_width / 2, y: g.y - corner.y + svg_height / 2 - real_height / 2};
+        //
+        //         // put nodes:
+        //         g.array.forEach(function (node) {
+        //             node.x += offset.x;
+        //             node.y += offset.y;
+        //         });
+        //     });
+        // }
 
         // starts box packing algorithm
         // desired ratio is 1 by default

--- a/WebCola/src/handledisconnected.ts
+++ b/WebCola/src/handledisconnected.ts
@@ -37,7 +37,6 @@
 
         calculate_bb(graphs);
         apply(graphs, desired_ratio);
-        // put_nodes_to_right_positions(graphs);
 
         // get bounding boxes for all separate graphs
         function calculate_bb(graphs) {
@@ -101,32 +100,6 @@
         //        .attr("r", 5).style('fill', "rgba(0,0,0,0.5)");
 
         //}
-
-        // actual assigning of position to nodes
-        // function put_nodes_to_right_positions(graphs) {
-        //     graphs.forEach(function (g) {
-        //         // calculate current graph center:
-        //         var center = { x: 0, y: 0 };
-        //
-        //         g.array.forEach(function (node) {
-        //             center.x += node.x;
-        //             center.y += node.y;
-        //         });
-        //
-        //         center.x /= g.array.length;
-        //         center.y /= g.array.length;
-        //
-        //         // calculate current top left corner:
-        //         var corner = { x: center.x - g.width / 2, y: center.y - g.height / 2 };
-        //         var offset = { x: g.x - corner.x + svg_width / 2 - real_width / 2, y: g.y - corner.y + svg_height / 2 - real_height / 2};
-        //
-        //         // put nodes:
-        //         g.array.forEach(function (node) {
-        //             node.x += offset.x;
-        //             node.y += offset.y;
-        //         });
-        //     });
-        // }
 
         // starts box packing algorithm
         // desired ratio is 1 by default

--- a/WebCola/src/layout.ts
+++ b/WebCola/src/layout.ts
@@ -493,13 +493,15 @@ import {separateGraphs, applyPacking} from './handledisconnected'
          * @param {number} [initialAllConstraintsIterations=0] initial layout iterations with all constraints including non-overlap
          * @param {number} [gridSnapIterations=0] iterations of "grid snap", which pulls nodes towards grid cell centers - grid of size node[0].width - only really makes sense if all nodes have the same width and height
          * @param [keepRunning=true] keep iterating asynchronously via the tick method
+         * @param [centerGraph=true] Center graph on restart
          */
         start(
             initialUnconstrainedIterations: number = 0,
             initialUserConstraintIterations: number = 0,
             initialAllConstraintsIterations: number = 0,
             gridSnapIterations: number = 0,
-            keepRunning = true
+            keepRunning = true,
+            centerGraph = true,
         ): this {
             var i: number,
                 j: number,
@@ -613,7 +615,7 @@ import {separateGraphs, applyPacking} from './handledisconnected'
             // apply initialIterations with user constraints but no nonoverlap constraints
             if (curConstraints.length > 0) this._descent.project = new Projection(this._nodes, this._groups, this._rootGroup, curConstraints).projectFunctions();
             this._descent.run(initialUserConstraintIterations);
-            this.separateOverlappingComponents(w, h);
+            this.separateOverlappingComponents(w, h, centerGraph);
 
             // subsequent iterations will apply all constraints
             this.avoidOverlaps(ao);
@@ -641,7 +643,7 @@ import {separateGraphs, applyPacking} from './handledisconnected'
             }
 
             this.updateNodePositions();
-            this.separateOverlappingComponents(w, h);
+            this.separateOverlappingComponents(w, h, centerGraph);
             return keepRunning ? this.resume() : this;
         }
 
@@ -683,13 +685,13 @@ import {separateGraphs, applyPacking} from './handledisconnected'
         }
 
         // recalculate nodes position for disconnected graphs
-        private separateOverlappingComponents(width: number, height: number): void {
+        private separateOverlappingComponents(width: number, height: number, centerGraph: boolean = true): void {
             // recalculate nodes position for disconnected graphs
             if (!this._distanceMatrix && this._handleDisconnected) {
                 let x = this._descent.x[0], y = this._descent.x[1];
                 this._nodes.forEach(function (v, i) { v.x = x[i], v.y = y[i]; });
                 var graphs = separateGraphs(this._nodes, this._links);
-                applyPacking(graphs, width, height, this._defaultNodeSize);
+                applyPacking(graphs, width, height, this._defaultNodeSize, 1, centerGraph);
                 this._nodes.forEach((v, i) => {
                     this._descent.x[0][i] = v.x, this._descent.x[1][i] = v.y;
                     if (v.bounds) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webcola",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "devDependencies": {
     "@types/d3": "^4.5.0",
     "@types/jquery": "^2.0.40",


### PR DESCRIPTION
This should fix #244. It adds another optional parameter to `simulation.start()` though. Perhaps we should consider adding an options object as parameter instead of additional parameters?