### PR TITLE
Add unpkg and jsdelivr fields to point to UMD

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   },
   "description": "WebCola =======",
   "main": "dist/index.js",
+  "unpkg": "WebCola/cola.min.js",
+  "jsdelivr": "WebCola/cola.min.js",
   "typings": "dist/index.d.ts",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
WebCola has UMD builds, which is great! This adds `unpkg` and `jsdelivr` fields, so that tools like d3-require and requirejs can easily require these builds - this means that if you depend on `https://unpkg.com/webcola@3`, you'll depend on the UMD build, instead of being redirected to the CommonJS `index.js` file.