### PR TITLE
Update Group typescript interface: set padding to be optional

### DIFF
--- a/WebCola/src/layout.ts
+++ b/WebCola/src/layout.ts
@@ -55,7 +55,7 @@ import {separateGraphs, applyPacking} from './handledisconnected'
         bounds?: Rectangle;
         leaves?: Node[];
         groups?: Group[];
-        padding: number;
+        padding?: number;
     }
 
     function isGroup(g: any): g is Group {


### PR DESCRIPTION
`Group` padding is not needed to be set as it is defaulted to 1, however the typescript type makes it required, which is not necessary.

See https://github.com/tgdwyer/WebCola/blob/master/WebCola/src/layout.ts#L235 for where it is defaulted.