### PR TITLE
FIX: fixing infinite loop / NaN length for edges when only one column/row in grid router

### DIFF
--- a/WebCola/src/gridrouter.ts
+++ b/WebCola/src/gridrouter.ts
@@ -112,6 +112,10 @@ import {Calculator} from './shortestpaths'
 
         // medial axes between node centres and also boundary lines for the grid
         private midPoints(a) {
+            if (a.length === 1) {
+                return [a[0]]
+            }
+
             var gap = a[1] - a[0];
             var mids = [a[0] - gap / 2];
             for (var i = 1; i < a.length; i++) {


### PR DESCRIPTION
Unrelated to the issue, but I ran into an infinite loop when building a graph in https://github.com/tgdwyer/WebCola/issues/291 that had only one column:

![Image 2020-04-22 at 5 27 35 PM](https://user-images.githubusercontent.com/4621962/80046481-8ef0ff00-84bf-11ea-9c8c-b3d01f9836c5.png)

Root cause was `this.edges` had `NaN` x and y coordinates because row / column midpoints were incorrectly calculated. In this PR, correctly calculating midpoints when there is only one row/column.
