### PR TITLE
fix-333-allow-dimension-based-distances

### DIFF
--- a/src/descent.ts
+++ b/src/descent.ts
@@ -103,6 +103,14 @@ DEBUG */
         private random = new PseudoRandom();
 
         public project: { (x0: number[], y0: number[], r: number[]): void }[] = null;
+        /** The dimension distance squared calculation (defaults to x*x)
+         * @property dimensionDistanceSquared {(number, number) => number}
+         * Can be replaced with a custom function.
+         * For example replacing with (i, x) => i==0? x*x/16 : x*x;
+         * has the effect of making horizontal distances larger than vertical
+         * distances.
+         */
+        public dimensionDistanceSquared: (i: number, x: number) => number = (i, x) => x * x;
 
         /**
          * @method constructor
@@ -215,7 +223,7 @@ DEBUG */
                         distanceSquared = 0;
                         for (i = 0; i < this.k; ++i) {
                             const dx = d[i] = x[i][u] - x[i][v];
-                            distanceSquared += d2[i] = dx * dx;
+                            distanceSquared += d2[i] = this.dimensionDistanceSquared(i,dx);
                         }
                         if (distanceSquared > 1e-9) break;
                         const rd = this.offsetDir();


### PR DESCRIPTION
Convert dx*dx into a property function so that it can be overriden but users who would like to vary the descent distance by dimension. This is useful when laying out rectangles, because it allows one axis to be weighted more heavily than another axis.

<img width="690" alt="Screen Shot 2022-12-27 at 3 06 10 PM" src="https://user-images.githubusercontent.com/49298/209735114-455577fa-4351-4da4-a456-d3560ba5c4ae.png">
